### PR TITLE
If reading progress is for trashed leaf, ignore it

### DIFF
--- a/app/controllers/books/bookmarks_controller.rb
+++ b/app/controllers/books/bookmarks_controller.rb
@@ -2,7 +2,7 @@ class Books::BookmarksController < ApplicationController
   include BookScoped
 
   def show
-    @leaf = @book.leaves.find(last_read_leaf_id) if last_read_leaf_id.present?
+    @leaf = @book.leaves.find_by(id: last_read_leaf_id) if last_read_leaf_id.present?
   end
 
   private

--- a/test/controllers/books/bookmarks_controller_test.rb
+++ b/test/controllers/books/bookmarks_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Books::BookmarksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in :kevin
+  end
+
+  test "show includes a link to read the last read leaf" do
+    cookies["reading_progress_#{books(:handbook).id}"] = "#{leaves(:welcome_page).id}/3"
+
+    get book_bookmark_url(books(:handbook))
+
+    assert_response :success
+    assert_select "a", /Resume reading/
+  end
+
+  test "show includes a link to start reading if the last read leaf has been trashed" do
+    leaves(:welcome_page).trashed!
+    cookies["reading_progress_#{books(:handbook).id}"] = "#{leaves(:welcome_page).id}/3"
+
+    get book_bookmark_url(books(:handbook))
+
+    assert_response :success
+    assert_select "a", /Start reading/
+  end
+
+  test "show includes a link to start reading if no reading progress has been recorded" do
+    get book_bookmark_url(books(:handbook))
+
+    assert_response :success
+    assert_select "a", /Start reading/
+  end
+end


### PR DESCRIPTION
There was an issue where trashing a leaf would crash the book index for people who had last read that leaf. If the tracked leaf is no longer present, we can just ignore it instead.