### PR TITLE
Drag to add

### DIFF
--- a/app/assets/stylesheets/arrangement.css
+++ b/app/assets/stylesheets/arrangement.css
@@ -33,6 +33,14 @@
   }
 }
 
+.arrangement-adding-mode
+  .arrangement__item {
+    * {
+      pointer-events: none;
+    }
+  }
+}
+
 .arrangement-cursor {
   border-style: dashed;
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,6 +11,8 @@ class PagesController < ApplicationController
     @leafable = new_page
     @book.press @leafable
 
+    position_new_leaf(@leafable.leaf)
+
     respond_to do |format|
       format.turbo_stream { render }
       format.html { redirect_to @book }
@@ -42,11 +44,17 @@ class PagesController < ApplicationController
       cookies.delete "reading_progress_#{@book.id}"
     end
 
+    def position_new_leaf(leaf)
+      if position = params[:position]&.to_i
+        leaf.move_to_position position
+      end
+    end
+
     def new_page
       Page.new page_params
     end
 
     def page_params
-      params.require(:page).permit(:title, :body)
+      params.fetch(:page, {}).permit(:title, :body)
     end
 end

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -9,6 +9,8 @@ class PicturesController < ApplicationController
     @leafable = new_picture
     @book.press @leafable
 
+    position_new_leaf(@leafable.leaf)
+
     respond_to do |format|
       format.turbo_stream { render }
       format.html { redirect_to @book }
@@ -36,11 +38,17 @@ class PicturesController < ApplicationController
   end
 
   private
+    def position_new_leaf(leaf)
+      if position = params[:position]&.to_i
+        leaf.move_to_position position
+      end
+    end
+
     def new_picture
       Picture.new picture_params
     end
 
     def picture_params
-      params.require(:picture).permit(:title, :image, :caption)
+      params.fetch(:picture, {}).permit(:title, :image, :caption)
     end
 end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -9,6 +9,8 @@ class SectionsController < ApplicationController
     @leafable = new_section
     @book.press @leafable
 
+    position_new_leaf(@leafable.leaf)
+
     respond_to do |format|
       format.turbo_stream { render }
       format.html { redirect_to @book }
@@ -36,11 +38,17 @@ class SectionsController < ApplicationController
   end
 
   private
+    def position_new_leaf(leaf)
+      if position = params[:position]&.to_i
+        leaf.move_to_position position
+      end
+    end
+
     def new_section
       Section.new section_params
     end
 
     def section_params
-      params.require(:section).permit(:title)
+      params.fetch(:section, {}).permit(:title)
     end
 end

--- a/app/helpers/arrangement_helper.rb
+++ b/app/helpers/arrangement_helper.rb
@@ -5,6 +5,7 @@ module ArrangementHelper
       arrangement_cursor_class: "arrangement-cursor",
       arrangement_selected_class: "arrangement-selected",
       arrangement_placeholder_class: "arrangement-placeholder",
+      arrangement_adding_mode_class: "arrangement-adding-mode",
       arrangement_move_mode_class: "arrangement-move-mode",
       arrangement_url_value: book_leaves_moves_url(book),
       reading_progress_book_id_value: book.id,

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -12,6 +12,16 @@ module BooksHelper
       }, &
   end
 
+  def book_part_create_button(book, kind, &)
+    url = url_for [ book, kind.new ]
+
+    button_to url, class: "btn btn--plain txt-medium fill-transparent disable-when-arranging", draggable: true,
+      data: {
+        action: "dragstart->arrangement#dragStartCreate dragend->arrangement#dragEndCreate",
+        arrangement_url_param: url
+      }, &
+  end
+
   def link_to_first_leafable(leaves)
     if first_leaf = leaves.first
       link_to leafable_path(first_leaf), data: { **hotkey_data_attributes("right") }, class: "txt-ink txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-start flex-item-justify-start", hidden: true do

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -12,14 +12,14 @@ module BooksHelper
       }, &
   end
 
-  def book_part_create_button(book, kind, &)
+  def book_part_create_button(book, kind, **, &)
     url = url_for [ book, kind.new ]
 
     button_to url, class: "btn btn--plain txt-medium fill-transparent disable-when-arranging", draggable: true,
       data: {
         action: "dragstart->arrangement#dragStartCreate dragend->arrangement#dragEndCreate",
         arrangement_url_param: url
-      }, &
+      }, **, &
   end
 
   def link_to_first_leafable(leaves)

--- a/app/javascript/controllers/arrangement_controller.js
+++ b/app/javascript/controllers/arrangement_controller.js
@@ -6,11 +6,13 @@ const Direction = {
   AFTER: 1
 }
 
+const NEW_ITEM_ID = "dragged_item"
+const NEW_ITEM_DATA_TYPE = "x-workbook/create"
 const ITEM_SELECTOR = "[data-arrangement-target=item]"
 
 export default class extends Controller {
   static targets = [ "container", "item", "layer", "dragImage" ]
-  static classes = [ "cursor", "selected", "placeholder", "moveMode" ]
+  static classes = [ "cursor", "selected", "placeholder", "addingMode", "moveMode" ]
   static values = { url: String }
 
   #cursorPosition
@@ -112,6 +114,32 @@ export default class extends Controller {
 
   // Actions - drag & drop
 
+  dragStartCreate(event) {
+    const entry = document.createElement("li")
+    entry.id = NEW_ITEM_ID
+    entry.innerHTML = "&nbsp;"
+    entry.dataset.arrangementTarget = "item"
+    this.containerTarget.prepend(entry)
+
+    event.dataTransfer.effectAllowed = "move"
+    event.dataTransfer.setData(NEW_ITEM_DATA_TYPE, event.params.url)
+
+    this.#dragItem = entry
+    this.#setSelection(entry, false)
+
+    this.containerTarget.classList.add(this.addingModeClass)
+    this.#enableDraggingLayer()
+  }
+
+  dragEndCreate(event) {
+    if (!this.#wasDropped) {
+      this.#dragItem.remove()
+    }
+
+    this.containerTarget.classList.remove(this.addingModeClass)
+    this.#disableDraggingLayer()
+  }
+
   dragStart(event) {
     this.#wasDropped = false
     this.#dragItem = event.target
@@ -126,16 +154,18 @@ export default class extends Controller {
       event.dataTransfer.setDragImage(this.dragImageTarget, 0, 0)
     }
 
-    this.#buildLayer()
-
-    setTimeout(() => {
-      this.containerTarget.style.opacity = "0"
-    }, 0)
+    this.#enableDraggingLayer()
   }
 
-  drop() {
+  drop(event) {
     this.#wasDropped = true
-    this.#submitMove()
+
+    const createURL = event.dataTransfer.getData(NEW_ITEM_DATA_TYPE)
+    if (createURL) {
+      this.#submitCreate(createURL)
+    } else {
+      this.#submitMove()
+    }
   }
 
   dragEnd() {
@@ -146,8 +176,7 @@ export default class extends Controller {
       this.#originalOrder = undefined
     }
 
-    this.containerTarget.style.opacity = "1"
-    this.#clearLayer()
+    this.#disableDraggingLayer()
   }
 
   dragOver(event) {
@@ -223,6 +252,19 @@ export default class extends Controller {
       }
     })
     this.#renderSelection()
+  }
+
+  #enableDraggingLayer() {
+    this.#buildLayer()
+
+    setTimeout(() => {
+      this.containerTarget.style.opacity = "0"
+    }, 0)
+  }
+
+  #disableDraggingLayer() {
+    this.containerTarget.style.opacity = "1"
+    this.#clearLayer()
   }
 
   #buildLayer() {
@@ -313,6 +355,15 @@ export default class extends Controller {
     ids.forEach((id) => body.append("id[]", id))
 
     post(this.urlValue, { body })
+  }
+
+  #submitCreate(url) {
+    const position = this.#selection[0]
+
+    const body = new FormData()
+    body.append("position", position)
+
+    post(url, { body, responseKind: "turbo-stream" })
   }
 
   get #selectionStart() {

--- a/app/views/books/_show.html.erb
+++ b/app/views/books/_show.html.erb
@@ -85,7 +85,7 @@
         <span class="for-screen-reader">Add a new picture page</span>
       <% end %>
 
-      <%= book_part_create_button book, Section do %>
+      <%= book_part_create_button book, Section, form_class: "flex-item-justify-start" do %>
         <svg viewBox="0 0 20 24" xmlns="http://www.w3.org/2000/svg" fill="var(--color-ink)" height="60vmin" width="60vmin">
           <path d="m15 11.5c-3.6 0-6.5-2.9-6.5-6.5s0-.2 0-.2h-6.3c-.3 0-.4.2-.4.4v16.9s0 .2.2 0h13.4c.3 0 .4-.2.4-.4v-10.3c-.2 0-.5 0-.8 0z" opacity=".3"/>
           <path d="m15.8 21.7c0 .3-.2.4-.4.4h-13.5-.2v-16.9c0-.3.2-.4.4-.4h6.3c0-.6.1-1.2.3-1.8h-6.9c-1 0-1.8.8-1.8 1.8v17.5c0 1 .8 1.8 1.8 1.8h14c.9 0 1.6-.6 1.8-1.4v-11.6c-.5.2-1.1.4-1.8.5v10.3z"/>

--- a/app/views/books/_show.html.erb
+++ b/app/views/books/_show.html.erb
@@ -63,7 +63,7 @@
 
   <div class="book__toolbar fill-white flex gap-half pad-block margin-block-end-half" data-controller="toc-view" data-toc-view-id-value="<%= dom_id(book) %>">
     <% if book.editable? %>
-      <%= button_to [ book, Page.new ], params: { page: { title: "Untitled"} }, class: "btn btn--plain txt-medium fill-transparent disable-when-arranging" do %>
+      <%= book_part_create_button book, Page do %>
         <svg viewBox="0 0 20 24" xmlns="http://www.w3.org/2000/svg" fill="var(--color-ink)" height="60vmin" width="60vmin">
           <path d="m15.8 21.7c0 .3-.2.4-.4.4h-13.5-.2v-16.9c0-.3.2-.4.4-.4h6.3c0-.6.1-1.2.3-1.8h-6.9c-1 0-1.8.8-1.8 1.8v17.5c0 1 .8 1.8 1.8 1.8h14c.9 0 1.6-.6 1.8-1.4v-11.6c-.5.2-1.1.4-1.8.5v10.3z"/>
           <path fill="var(--color-positive)" d="m15 0c-2.8 0-5 2.2-5 5s2.2 5 5 5 5-2.2 5-5-2.2-5-5-5zm1.9 5.6h-1.2c-.1 0-.2 0-.2.2v1.2c0 .3-.3.6-.6.6s-.6-.3-.6-.6v-1.2c0-.1 0-.2-.2-.2h-1.2c-.3 0-.6-.3-.6-.6s.3-.6.6-.6h1.2c.1 0 .2 0 .2-.2v-1.2c0-.3.3-.6.6-.6s.6.3.6.6v1.2c0 .1 0 .2.2.2h1.2c.3 0 .6.3.6.6s-.3.6-.6.6z"/>
@@ -75,7 +75,7 @@
         <span class="for-screen-reader">Add a new text page</span>
       <% end %>
 
-      <%= button_to [ book, Picture.new ], params: { picture: { title: "Picture"} }, class: "btn btn--plain txt-medium fill-transparent disable-when-arranging" do %>
+      <%= book_part_create_button book, Picture do %>
         <svg viewBox="0 0 20 24" xmlns="http://www.w3.org/2000/svg" fill="var(--color-ink)" height="60vmin" width="60vmin">
           <path d="m14.4 16.8s.2-.2.2-.3v-5.1c-2.8-.2-5.1-2.2-5.8-4.9h-4.2c-.8 0-1.4.6-1.4 1.4v11.1c0 .8.6 1.5 1.5 1.5h1.2s.2 0 .3-.2l4.4-6.8c.2-.3.3-.4.7-.4s.5.2.7.4l2.2 3.1c0 .2.3.2.4 0zm-7.3-1.9c-.9 0-1.7-.8-1.7-1.7s.8-1.7 1.7-1.7 1.7.8 1.7 1.7-.8 1.7-1.7 1.7z"/>
           <path d="m11.2 15.8c0-.2-.2-.2-.3 0s-2.6 4.1-2.6 4.1v.4h.2 4.3c.3 0 .7-.2.8-.3s.2-.2 0-.3l-2.4-3.8z"/>
@@ -85,7 +85,7 @@
         <span class="for-screen-reader">Add a new picture page</span>
       <% end %>
 
-      <%= button_to [ book, Section.new ], params: { section: { title: "Section"} }, class: "btn btn--plain txt-medium fill-transparent disable-when-arranging", form_class: "flex-item-justify-start" do %>
+      <%= book_part_create_button book, Section do %>
         <svg viewBox="0 0 20 24" xmlns="http://www.w3.org/2000/svg" fill="var(--color-ink)" height="60vmin" width="60vmin">
           <path d="m15 11.5c-3.6 0-6.5-2.9-6.5-6.5s0-.2 0-.2h-6.3c-.3 0-.4.2-.4.4v16.9s0 .2.2 0h13.4c.3 0 .4-.2.4-.4v-10.3c-.2 0-.5 0-.8 0z" opacity=".3"/>
           <path d="m15.8 21.7c0 .3-.2.4-.4.4h-13.5-.2v-16.9c0-.3.2-.4.4-.4h6.3c0-.6.1-1.2.3-1.8h-6.9c-1 0-1.8.8-1.8 1.8v17.5c0 1 .8 1.8 1.8 1.8h14c.9 0 1.6-.6 1.8-1.4v-11.6c-.5.2-1.1.4-1.8.5v10.3z"/>

--- a/app/views/leaves/_create.turbo_stream.erb
+++ b/app/views/leaves/_create.turbo_stream.erb
@@ -1,0 +1,13 @@
+<% if position.present? %>
+  <%= turbo_stream.replace :dragged_item do %>
+    <%= render "leaves/edit", leaf: leaf, css_class: "wiggle" do %>
+      <span data-controller="scroll-into-view"></span>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.append :leaves do %>
+    <%= render "leaves/edit", leaf: leaf, css_class: "wiggle" do %>
+      <span data-controller="scroll-into-view"></span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/pages/create.turbo_stream.erb
+++ b/app/views/pages/create.turbo_stream.erb
@@ -1,5 +1,1 @@
-<%= turbo_stream.append :leaves do %>
-  <%= render "leaves/edit", leaf: @leafable.leaf, css_class: "wiggle" do %>
-    <span data-controller="scroll-into-view"></span>
-  <% end %>
-<% end %>
+<%= render "leaves/create", leaf: @leafable.leaf, position: params[:position] %>

--- a/app/views/pictures/create.turbo_stream.erb
+++ b/app/views/pictures/create.turbo_stream.erb
@@ -1,5 +1,1 @@
-<%= turbo_stream.append :leaves do %>
-  <%= render "leaves/edit", leaf: @leafable.leaf, css_class: "wiggle" do %>
-    <span data-controller="scroll-into-view"></span>
-  <% end %>
-<% end %>
+<%= render "leaves/create", leaf: @leafable.leaf, position: params[:position] %>

--- a/app/views/sections/create.turbo_stream.erb
+++ b/app/views/sections/create.turbo_stream.erb
@@ -1,5 +1,1 @@
-<%= turbo_stream.append :leaves do %>
-  <%= render "leaves/edit", leaf: @leafable.leaf, css_class: "wiggle" do %>
-    <span data-controller="scroll-into-view"></span>
-  <% end %>
-<% end %>
+<%= render "leaves/create", leaf: @leafable.leaf, position: params[:position] %>

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -15,6 +15,24 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal books(:handbook), new_page.leaf.book
   end
 
+  test "create with default params" do
+    assert_changes -> { Page.count }, +1 do
+      post book_pages_path(books(:handbook))
+    end
+    assert_redirected_to books(:handbook)
+
+    assert_equal "Untitled", Page.last.title
+  end
+
+  test "create at a specific position" do
+    assert_changes -> { Page.count }, +1 do
+      post book_pages_path(books(:handbook), params: { position: 2 })
+    end
+    assert_redirected_to books(:handbook)
+
+    assert_equal 2, books(:handbook).leaves.before(Page.last.leaf).count
+  end
+
   test "update" do
     get edit_leafable_path(leaves(:welcome_page))
     assert_response :ok


### PR DESCRIPTION
With this, we have two ways to add new parts to a book:

- Click the button to add a part at the end (this is the existing behaviour)
- Drag a button to the list, to add at a specific place

https://github.com/basecamp/workbook/assets/1186763/a3409c4b-216d-42d5-84e9-04b4f350c5b3

It still needs a little bit of polish: there's a little unexpected scrolling at times (I think due to the scrollIntoView on the new part); and the new part briefly flashes blue right after dropping, due to a CSS style that gets revealed.

