### PR TITLE
Disable hotkeys in edit pages

### DIFF
--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -24,7 +24,7 @@ module BooksHelper
 
   def link_to_first_leafable(leaves)
     if first_leaf = leaves.first
-      link_to leafable_path(first_leaf), data: { **hotkey_data_attributes("right") }, class: "txt-ink txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-start flex-item-justify-start", hidden: true do
+      link_to leafable_path(first_leaf), data: hotkey_data_attributes("right"), class: "txt-ink txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-start flex-item-justify-start", hidden: true do
         tag.span(class: "btn") do
           image_tag("arrow-right.svg", aria: { hidden: true }, size: 24) + tag.span("Start reading", class: "for-screen-reader")
         end + tag.span(first_leaf.title, class: "overflow-ellipsis")
@@ -32,28 +32,28 @@ module BooksHelper
     end
   end
 
-  def link_to_previous_leafable(leaf)
+  def link_to_previous_leafable(leaf, hotkey: true)
     if previous_leaf = leaf.previous
-      link_to leaf.book.editable? ? edit_leafable_path(previous_leaf) : leafable_path(previous_leaf), data: { **hotkey_data_attributes("left") }, class: "btn flex-item-justify-start" do
+      link_to leaf.book.editable? ? edit_leafable_path(previous_leaf) : leafable_path(previous_leaf), data: hotkey_data_attributes("left", enabled: hotkey), class: "btn flex-item-justify-start" do
         image_tag("arrow-left.svg", aria: { hidden: true }, size: 24) + tag.span(previous_leaf.title, class: "for-screen-reader")
       end
     else
-      link_to Current.user ? book_path(leaf.book) : public_book_path(leaf.book.slug), data: { **hotkey_data_attributes("left") }, class: "btn flex-item-justify-start" do
+      link_to Current.user ? book_path(leaf.book) : public_book_path(leaf.book.slug), data: hotkey_data_attributes("left", enabled: hotkey), class: "btn flex-item-justify-start" do
         image_tag("arrow-left.svg", aria: { hidden: true }, size: 24) + tag.span("Table of contents", class: "for-screen-reader")
       end
     end
   end
 
-  def link_to_next_leafable(leaf)
+  def link_to_next_leafable(leaf, hotkey: true)
     if next_leaf = leaf.next
-      link_to leaf.book.editable? ? edit_leafable_path(next_leaf) : leafable_path(next_leaf), data: { **hotkey_data_attributes("right") }, class: "txt-ink txt-medium txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-end flex-item-justify-end" do
+      link_to leaf.book.editable? ? edit_leafable_path(next_leaf) : leafable_path(next_leaf), data: hotkey_data_attributes("right", enabled: hotkey), class: "txt-ink txt-medium txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-end flex-item-justify-end" do
         tag.span(next_leaf.title, class: "overflow-ellipsis") +
         tag.span(class: "btn txt-medium") do
           image_tag("arrow-right.svg", aria: { hidden: true }, size: 24) + tag.span("Next", class: "for-screen-reader")
         end
       end
     else
-      link_to Current.user ? book_path(leaf.book) : public_book_path(leaf.book.slug), data: { **hotkey_data_attributes("right") }, class: "txt-ink txt-medium txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-end flex-item-justify-end" do
+      link_to Current.user ? book_path(leaf.book) : public_book_path(leaf.book.slug), data: hotkey_data_attributes("right", enabled: hotkey), class: "txt-ink txt-medium txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-end flex-item-justify-end" do
         tag.span("End", class: "overflow-ellipsis") +
         tag.span(class: "btn txt-medium") do
           image_tag("arrow-right.svg", aria: { hidden: true }, size: 24) + tag.span("End", class: "for-screen-reader")
@@ -63,7 +63,9 @@ module BooksHelper
   end
 
   private
-    def hotkey_data_attributes(key)
-      { controller: "hotkey", action: "keydown.#{key}@document->hotkey#click" }
+    def hotkey_data_attributes(key, enabled: true)
+      if enabled
+        { controller: "hotkey", action: "keydown.#{key}@document->hotkey#click" }
+      end
     end
 end

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :header do %>
   <nav>
-    <%= link_to_previous_leafable(@leaf) %>
+    <%= link_to_previous_leafable(@leaf, hotkey: false) %>
 
     <div class="breadcrumbs">
       <%= link_to books_path do %>
@@ -31,7 +31,7 @@
     <%= render "leaves/delete", leaf: @leaf %>
 
     <span class="flex-item-justify-end flex-item-grow">
-      <%= link_to_next_leafable(@leaf) %>
+      <%= link_to_next_leafable(@leaf, hotkey: false) %>
     <span>
   </span>
 <% end %>

--- a/app/views/pictures/edit.html.erb
+++ b/app/views/pictures/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :header do %>
   <nav>
-    <%= link_to_previous_leafable(@leaf) %>
+    <%= link_to_previous_leafable(@leaf, hotkey: false) %>
 
     <div class="breadcrumbs">
       <%= link_to books_path do %>
@@ -30,7 +30,7 @@
     <%= render "leaves/delete", leaf: @leaf %>
 
     <span class="flex-item-justify-end flex-item-grow">
-      <%= link_to_next_leafable(@leaf) %>
+      <%= link_to_next_leafable(@leaf, hotkey: false) %>
     <span>
   </span>
 <% end %>

--- a/app/views/sections/edit.html.erb
+++ b/app/views/sections/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :header do %>
   <nav>
-    <%= link_to_previous_leafable(@leaf) %>
+    <%= link_to_previous_leafable(@leaf, hotkey: false) %>
 
     <div class="breadcrumbs">
       <%= link_to books_path do %>
@@ -28,7 +28,7 @@
     <%= render "leaves/delete", leaf: @leaf %>
 
     <span class="flex-item-justify-end flex-item-grow">
-      <%= link_to_next_leafable(@leaf) %>
+      <%= link_to_next_leafable(@leaf, hotkey: false) %>
     <span>
   </span>
 <% end %>


### PR DESCRIPTION
They interfere with moving the cursor with the keyboard in the editor. But even if they didn't, they make too easy to move away from the page and lose any unsaved changes.