### PR TITLE
Use toggle to switch TOC links for edit/read

### DIFF
--- a/app/assets/stylesheets/toc.css
+++ b/app/assets/stylesheets/toc.css
@@ -114,6 +114,16 @@
   }
 }
 
+.toc__link, .toc__title {
+  body:has(#edit_mode_enabled:not(:checked)) &.hide_from_reading_mode {
+    display: none;
+  }
+
+  body:has(#edit_mode_enabled:checked) &.hide_from_edit_mode {
+    display: none;
+  }
+}
+
 .toc__title {
   --title-border-color: var(--color-subtle-dark);
 

--- a/app/helpers/books/editing_helper.rb
+++ b/app/helpers/books/editing_helper.rb
@@ -1,0 +1,7 @@
+module Books::EditingHelper
+  def editing_mode_toggle_switch(leaf: nil)
+    edit_url = edit_leafable_path(leaf) if leaf
+    read_url = leafable_path(leaf) if leaf
+    render "books/edit_mode", edit_url: edit_url, read_url: read_url
+  end
+end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -32,9 +32,10 @@ module BooksHelper
     end
   end
 
-  def link_to_previous_leafable(leaf, hotkey: true)
+  def link_to_previous_leafable(leaf, hotkey: true, for_edit: false)
     if previous_leaf = leaf.previous
-      link_to leaf.book.editable? ? edit_leafable_path(previous_leaf) : leafable_path(previous_leaf), data: hotkey_data_attributes("left", enabled: hotkey), class: "btn flex-item-justify-start" do
+      path = for_edit ? edit_leafable_path(previous_leaf) : leafable_path(previous_leaf)
+      link_to path, data: hotkey_data_attributes("left", enabled: hotkey), class: "btn flex-item-justify-start" do
         image_tag("arrow-left.svg", aria: { hidden: true }, size: 24) + tag.span(previous_leaf.title, class: "for-screen-reader")
       end
     else
@@ -44,9 +45,10 @@ module BooksHelper
     end
   end
 
-  def link_to_next_leafable(leaf, hotkey: true)
+  def link_to_next_leafable(leaf, hotkey: true, for_edit: false)
     if next_leaf = leaf.next
-      link_to leaf.book.editable? ? edit_leafable_path(next_leaf) : leafable_path(next_leaf), data: hotkey_data_attributes("right", enabled: hotkey), class: "txt-ink txt-medium txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-end flex-item-justify-end" do
+      path = for_edit ? edit_leafable_path(next_leaf) : leafable_path(next_leaf)
+      link_to path, data: hotkey_data_attributes("right", enabled: hotkey), class: "txt-ink txt-medium txt-undecorated flex align-center gap full-width flex-item-grow min-width justify-end flex-item-justify-end" do
         tag.span(next_leaf.title, class: "overflow-ellipsis") +
         tag.span(class: "btn txt-medium") do
           image_tag("arrow-right.svg", aria: { hidden: true }, size: 24) + tag.span("Next", class: "for-screen-reader")

--- a/app/helpers/leaves_helper.rb
+++ b/app/helpers/leaves_helper.rb
@@ -6,12 +6,4 @@ module LeavesHelper
       reading_tracker_leaf_id_value: leaf.id
     }, **options, &block
   end
-
-  def show_or_edit_leafable_path(leaf)
-    if leaf.book.editable?
-      edit_leafable_path(leaf)
-    else
-      leafable_path(leaf)
-    end
-  end
 end

--- a/app/javascript/controllers/edit_mode_controller.js
+++ b/app/javascript/controllers/edit_mode_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+import { readCookie, setCookie } from "helpers/cookie_helpers"
+
+export default class extends Controller {
+  static values = { editUrl: String, readUrl: String }
+  static targets = [ "switch" ]
+
+  connect() {
+    this.switchTarget.checked = this.#savedCheckedState
+  }
+
+  change({ target: { checked } }) {
+    setCookie("edit_mode", checked)
+
+    if (checked && this.editUrlValue) {
+      Turbo.visit(this.editUrlValue)
+    }
+    if (!checked && this.readUrlValue) {
+      Turbo.visit(this.readUrlValue)
+    }
+  }
+
+  get #savedCheckedState() {
+    return readCookie("edit_mode") === "true"
+  }
+}

--- a/app/views/books/_edit_mode.html.erb
+++ b/app/views/books/_edit_mode.html.erb
@@ -1,7 +1,9 @@
-<%= tag.div data: { controller: "edit-mode", edit_mode_edit_url_value: edit_url, edit_mode_read_url_value: read_url } do %>
+<%= tag.div class: "flex align-center gap", data: { controller: "edit-mode", edit_mode_edit_url_value: edit_url, edit_mode_read_url_value: read_url } do %>
+  <%= image_tag "eye.svg", aria: { hidden: true }, size: 32, class: "colorize--black" %>
   <label class="switch txt-medium">
     <%= check_box_tag :edit_mode_enabled, class: "switch__input", data: { edit_mode_target: "switch", action: "edit-mode#change" } %>
     <span class="switch__btn round"></span>
     <span class="for-screen-reader">Editing mode</span>
   </label>
+  <%= image_tag "write.svg", aria: { hidden: true }, size: 28, class: "colorize--black" %>
 <% end %>

--- a/app/views/books/_edit_mode.html.erb
+++ b/app/views/books/_edit_mode.html.erb
@@ -1,0 +1,7 @@
+<%= tag.div data: { controller: "edit-mode", edit_mode_edit_url_value: edit_url, edit_mode_read_url_value: read_url } do %>
+  <label class="switch txt-medium">
+    <%= check_box_tag :edit_mode_enabled, class: "switch__input", data: { edit_mode_target: "switch", action: "edit-mode#change" } %>
+    <span class="switch__btn round"></span>
+    <span class="for-screen-reader">Editing mode</span>
+  </label>
+<% end %>

--- a/app/views/books/_show.html.erb
+++ b/app/views/books/_show.html.erb
@@ -48,7 +48,9 @@
         <span class="for-screen-reader">Edit book settings</span>
       <% end %>
 
-      <%= editing_mode_toggle_switch %>
+      <span hidden>
+        <%= editing_mode_toggle_switch %>
+      </span>
     <% end %>
   </nav>
 <% end %>

--- a/app/views/books/_show.html.erb
+++ b/app/views/books/_show.html.erb
@@ -47,6 +47,8 @@
         <%= image_tag "settings.svg", aria: { hidden: true }, size: 24 %>
         <span class="for-screen-reader">Edit book settings</span>
       <% end %>
+
+      <%= editing_mode_toggle_switch %>
     <% end %>
   </nav>
 <% end %>

--- a/app/views/leaves/_edit_footer.html.erb
+++ b/app/views/leaves/_edit_footer.html.erb
@@ -1,0 +1,9 @@
+<% content_for :footer do %>
+  <span class="flex justify-start">
+    <%= render "leaves/delete", leaf: leaf %>
+
+    <span class="flex-item-justify-end flex-item-grow">
+      <%= link_to_next_leafable(leaf, hotkey: false, for_edit: true) %>
+    <span>
+  </span>
+<% end %>

--- a/app/views/leaves/_header.html.erb
+++ b/app/views/leaves/_header.html.erb
@@ -9,17 +9,14 @@
     <strong><%= leaf.leafable.title %></strong>
   </div>
 
-  <button class="btn flex-item-justify-end" data-action="fullscreen#toggle">
+  <button class="btn flex-item-justify-end" data-action="fullscreen#toggle" hidden>
     <%= image_tag "expand.svg", aria: { hidden: true }, size: 24 %>
     <span class="for-screen-reader">Enter fullscreen</span>
   </button>
 
   <% if book.editable? %>
-    <%= link_to edit_leafable_path(leaf), class: "btn" do %>
-      <%= image_tag "pencil.svg", aria: { hidden: true }, size: 24 %>
-      <span class="for-screen-reader">Edit</span>
-    <% end %>
-
-    <%= editing_mode_toggle_switch(leaf: leaf) %>
+    <span class="flex-item-justify-end">
+      <%= editing_mode_toggle_switch(leaf: leaf) %>
+    <span>
   <% end %>
 <% end %>

--- a/app/views/leaves/_header.html.erb
+++ b/app/views/leaves/_header.html.erb
@@ -19,5 +19,7 @@
       <%= image_tag "pencil.svg", aria: { hidden: true }, size: 24 %>
       <span class="for-screen-reader">Edit</span>
     <% end %>
+
+    <%= editing_mode_toggle_switch(leaf: leaf) %>
   <% end %>
 <% end %>

--- a/app/views/leaves/_leaf.html.erb
+++ b/app/views/leaves/_leaf.html.erb
@@ -2,7 +2,11 @@
   <%= image_tag "handle.svg", aria: { hidden: true }, size: 24, class: "arrangement__handle translucent colorize--black" %>
 
   <div class="toc__thumbnail">
-    <%= link_to show_or_edit_leafable_path(leaf), class: "toc__link", data: { turbo_frame: "_top" } do %>
+    <%= link_to edit_leafable_path(leaf), class: "toc__link hide_from_reading_mode", data: { turbo_frame: "_top" } do %>
+      <span class="for-screen-reader">Edit <%= leaf.title %></span>
+    <% end %>
+
+    <%= link_to leafable_path(leaf), class: "toc__link hide_from_edit_mode", data: { turbo_frame: "_top" } do %>
       <span class="for-screen-reader">Open <%= leaf.title %></span>
     <% end %>
 
@@ -15,7 +19,11 @@
     <% end %>
   </div>
 
-  <%= link_to show_or_edit_leafable_path(leaf), class: "toc__title min-width", data: { turbo_frame: "_top" } do %>
+  <%= link_to edit_leafable_path(leaf), class: "toc__title min-width hide_from_reading_mode", data: { turbo_frame: "_top" } do %>
+    <span class="overflow-ellipsis"><%= leaf.title %></span>
+  <% end %>
+
+  <%= link_to leafable_path(leaf), class: "toc__title min-width hide_from_edit_mode", data: { turbo_frame: "_top" } do %>
     <span class="overflow-ellipsis"><%= leaf.title %></span>
   <% end %>
 

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -18,6 +18,8 @@
       <%= image_tag "check.svg", aria: { hidden: true }, size: 24 %>
       <span class="for-screen-reader">Save</span>
     </button>
+
+    <%= editing_mode_toggle_switch(leaf: @leaf) %>
   </nav>
 <% end %>
 
@@ -26,12 +28,4 @@
   <%= render "pages/form", book: @book, page: @page %>
 </article>
 
-<% content_for :footer do %>
-  <span class="flex justify-start">
-    <%= render "leaves/delete", leaf: @leaf %>
-
-    <span class="flex-item-justify-end flex-item-grow">
-      <%= link_to_next_leafable(@leaf, hotkey: false) %>
-    <span>
-  </span>
-<% end %>
+<%= render "leaves/edit_footer", leaf: @leaf %>

--- a/app/views/pictures/edit.html.erb
+++ b/app/views/pictures/edit.html.erb
@@ -18,6 +18,8 @@
       <%= image_tag "check.svg", aria: { hidden: true }, size: 24 %>
       <span class="for-screen-reader">Save</span>
     </button>
+
+    <%= editing_mode_toggle_switch(leaf: @leaf) %>
   </nav>
 <% end %>
 
@@ -25,12 +27,4 @@
   <%= render "pictures/form", book: @book, picture: @picture %>
 </div>
 
-<% content_for :footer do %>
-  <span class="flex justify-start">
-    <%= render "leaves/delete", leaf: @leaf %>
-
-    <span class="flex-item-justify-end flex-item-grow">
-      <%= link_to_next_leafable(@leaf, hotkey: false) %>
-    <span>
-  </span>
-<% end %>
+<%= render "leaves/edit_footer", leaf: @leaf %>

--- a/app/views/sections/edit.html.erb
+++ b/app/views/sections/edit.html.erb
@@ -16,6 +16,8 @@
       <%= image_tag "check.svg", aria: { hidden: true }, size: 24 %>
       <span class="for-screen-reader">Save</span>
     </button>
+
+    <%= editing_mode_toggle_switch(leaf: @leaf) %>
   </nav>
 <% end %>
 
@@ -23,12 +25,4 @@
   <%= render "sections/form", book: @book, section: @section %>
 </div>
 
-<% content_for :footer do %>
-  <span class="flex justify-start">
-    <%= render "leaves/delete", leaf: @leaf %>
-
-    <span class="flex-item-justify-end flex-item-grow">
-      <%= link_to_next_leafable(@leaf, hotkey: false) %>
-    <span>
-  </span>
-<% end %>
+<%= render "leaves/edit_footer", leaf: @leaf %>


### PR DESCRIPTION
This adds a checkbox switch in the header that toggles between read & edit modes.

The mode you're in dictates where the navigation links go (i.e., in edit mode they go to the edit pages). If you change mode while looking at a leafable, you'll switch to the appropriate view for that leafable.

This still needs some improvements to the styles to make it look better, and to make the transitions between modes smoother.

cc @jzimdars 