### PR TITLE
Wire up everyone access for books

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -12,7 +12,7 @@ class BooksController < ApplicationController
   end
 
   def create
-    book = Current.user.books.editable.create! book_params
+    book = Book.create! book_params
     update_accesses(book)
 
     redirect_to book
@@ -53,11 +53,14 @@ class BooksController < ApplicationController
     end
 
     def book_params
-      params.require(:book).permit(:title, :subtitle, :author, :cover, :remove_cover)
+      params.require(:book).permit(:title, :subtitle, :author, :cover, :remove_cover, :everyone_access)
     end
 
     def update_accesses(book)
-      book.update_accesses(Array(params[:reader_ids]), Array(params[:editor_ids]), excluding: Current.user)
+      editors = [ Current.user.id, *params[:editor_ids]&.map(&:to_i) ]
+      readers = [ Current.user.id, *params[:reader_ids]&.map(&:to_i) ]
+
+      book.update_access(editors: editors, readers: readers)
     end
 
     def remove_cover

--- a/app/models/book/accesses.rb
+++ b/app/models/book/accesses.rb
@@ -3,6 +3,7 @@ module Book::Accesses
 
   included do
     has_many :accesses, dependent: :destroy
+    scope :with_everyone_access, -> { where(everyone_access: true) }
   end
 
   def accessable?(user: Current.user)
@@ -17,18 +18,16 @@ module Book::Accesses
     accesses.find_by(user: user)
   end
 
-  def update_accesses(reader_ids, editor_ids, excluding:)
-    update_access_levels(reader_ids, :reader)
-    update_access_levels(editor_ids, :editor)
+  def update_access(editors:, readers:)
+    editors = Set.new(editors)
+    readers = Set.new(everyone_access? ? User.active.ids : readers)
 
-    exclude_ids = Array(excluding).map(&:id)
-    accesses.where.not(user_id: reader_ids + editor_ids + exclude_ids).delete_all
+    all = editors + readers
+    all_accesses = all.collect { |user_id|
+      { user_id: user_id, level: editors.include?(user_id) ? :editor : :reader }
+    }
+
+    accesses.upsert_all(all_accesses, unique_by: [ :book_id, :user_id ])
+    accesses.where.not(user_id: all).delete_all
   end
-
-  private
-    def update_access_levels(user_ids, level)
-      user_ids.each do |user_id|
-        accesses.find_or_initialize_by(user_id: user_id).update! level: level
-      end
-    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,9 @@ class User < ApplicationRecord
   has_secure_password validations: false
 
   has_many :accesses, dependent: :destroy
-  has_many :books, through: :accesses do
-    def editable
-      merge(Access.editor)
-    end
-  end
+  has_many :books, through: :accesses
+
+  after_create :grant_access_to_everyone_books
 
   scope :active, -> { where(active: true) }
   scope :ordered, -> { order(:name) }
@@ -28,5 +26,10 @@ class User < ApplicationRecord
   private
     def deactived_email_address
       email_address&.gsub(/@/, "-deactivated-#{SecureRandom.uuid}@")
+    end
+
+    def grant_access_to_everyone_books
+      all_accesses = Book.with_everyone_access.ids.collect { |id| { book_id: id, level: :reader } }
+      accesses.insert_all(all_accesses)
     end
 end

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -48,8 +48,8 @@
 
       <hr class="flex-item-grow margin-none" aria-hidden="true" style="--border-style: dashed">
 
-      <label for="everyone_reads" class="switch">
-        <input type="checkbox" id="everyone_reads" class="switch__input book-access__switch" checked="checked">
+      <label for="book_everyone_access" class="switch">
+        <%= form.check_box :everyone_access, class: "switch__input book-access__switch" %>
         <span class="switch__btn"></span>
         <span class="for-screen-reader">Only allow some people to read this book</span>
       </label>

--- a/db/migrate/20240606134124_add_everyone_access_to_books.rb
+++ b/db/migrate/20240606134124_add_everyone_access_to_books.rb
@@ -1,0 +1,5 @@
+class AddEveryoneAccessToBooks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :books, :everyone_access, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_05_28_211134) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_06_134124) do
   create_table "accesses", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "book_id", null: false
@@ -77,6 +77,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_05_28_211134) do
     t.string "author"
     t.boolean "published", default: false, null: false
     t.string "slug"
+    t.boolean "everyone_access", default: true, null: false
     t.index ["published"], name: "index_books_on_published"
     t.index ["slug"], name: "index_books_on_slug", unique: true
   end

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -15,7 +15,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
 
   test "create makes the current user an editor" do
     assert_difference -> { Book.count }, +1 do
-      post books_url, params: { book: { title: "New Book" } }
+      post books_url, params: { book: { title: "New Book", everyone_access: false } }
     end
 
     assert_redirected_to book_url(Book.last)
@@ -29,7 +29,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
 
   test "create sets additional accesses" do
     assert_difference -> { Book.count }, +1 do
-      post books_url, params: { book: { title: "New Book" }, "editor_ids[]": users(:jz).id, "reader_ids[]": users(:jason).id }
+      post books_url, params: { book: { title: "New Book", everyone_access: false }, "editor_ids[]": users(:jz).id, "reader_ids[]": users(:jason).id }
     end
 
     book = Book.last

--- a/test/models/book/accesses_test.rb
+++ b/test/models/book/accesses_test.rb
@@ -13,14 +13,6 @@ class Book::AccessesTest < ActiveSupport::TestCase
     end
   end
 
-  test "new users get access to everyone books" do
-    book = Book.create!(title: "My new book", everyone_access: true)
-    user = User.create!(email_address: "bob@example.com", name: "Bob", password: "secret123456")
-
-    assert book.accessable?(user: user)
-    assert_not book.editable?(user: user)
-  end
-
   test "update_access updates existing access" do
     book = Book.create!(title: "My new book", everyone_access: false)
 

--- a/test/models/book/accesses_test.rb
+++ b/test/models/book/accesses_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Book::AccessesTest < ActiveSupport::TestCase
+  test "update_access always grants read access to everyone when everyone_access is set" do
+    book = Book.create!(title: "My new book")
+    book.update_access(editors: [], readers: [])
+
+    assert book.everyone_access?
+
+    User.all.each do |user|
+      assert book.accessable?(user: user)
+      assert_not book.editable?(user: user)
+    end
+  end
+
+  test "new users get access to everyone books" do
+    book = Book.create!(title: "My new book", everyone_access: true)
+    user = User.create!(email_address: "bob@example.com", name: "Bob", password: "secret123456")
+
+    assert book.accessable?(user: user)
+    assert_not book.editable?(user: user)
+  end
+
+  test "update_access updates existing access" do
+    book = Book.create!(title: "My new book", everyone_access: false)
+
+    book.update_access(editors: [ users(:kevin).id ], readers: [])
+    assert book.editable?(user: users(:kevin))
+
+    book.update_access(editors: [], readers: [ users(:kevin).id ])
+    assert book.accessable?(user: users(:kevin))
+    assert_not book.editable?(user: users(:kevin))
+  end
+
+  test "update_access removes stale accesses" do
+    book = Book.create!(title: "My new book", everyone_access: false)
+
+    book.update_access(editors: [ users(:kevin).id ], readers: [ users(:jz).id ])
+    assert_equal 2, book.accesses.size
+
+    book.update_access(editors: [ users(:kevin).id ], readers: [])
+    assert_equal 1, book.accesses.size
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,4 +5,16 @@ class UserTest < ActiveSupport::TestCase
     users(:david).update(password: "secret" * 50)
     assert users(:david).valid?
   end
+
+  test "new users get access to everyone books" do
+    everyone_book = Book.create!(title: "My new book", everyone_access: true)
+    other_book = Book.create!(title: "My secret book", everyone_access: false)
+
+    bob = User.create!(email_address: "bob@example.com", name: "Bob", password: "secret123456")
+
+    assert everyone_book.accessable?(user: bob)
+    assert_not everyone_book.editable?(user: bob)
+
+    assert_not other_book.accessable?(user: bob)
+  end
 end


### PR DESCRIPTION
This wires up the "everyone" access mode for books, so changes made in this part of the UI now update as they should:

https://github.com/basecamp/writebook/assets/1186763/f683054a-fbb0-443b-ad1f-904557eb54b5

There's now an `everyone_access` attribute on the `Book`, and the permission handled has been updated to a) take it into account, and b) be more efficient than before. And, when new users are created, they automatically get access to all the everyone books.