### PR TITLE
Use signed URLs for QR code links

### DIFF
--- a/app/controllers/qr_code_controller.rb
+++ b/app/controllers/qr_code_controller.rb
@@ -2,10 +2,10 @@ class QrCodeController < ApplicationController
   allow_unauthenticated_access
 
   def show
-    url = Base64.urlsafe_decode64(params[:id])
-    qr_code = RQRCode::QRCode.new(url).as_svg(viewbox: true, fill: :white, color: :black)
+    qr_code_link = QrCodeLink.from_signed(params[:id])
+    svg = RQRCode::QRCode.new(qr_code_link.url).as_svg(viewbox: true, fill: :white, color: :black)
 
     expires_in 1.year, public: true
-    render plain: qr_code, content_type: "image/svg+xml"
+    render plain: svg, content_type: "image/svg+xml"
   end
 end

--- a/app/helpers/invitations_helper.rb
+++ b/app/helpers/invitations_helper.rb
@@ -16,7 +16,7 @@ module InvitationsHelper
   end
 
   def qr_code_image(url)
-    id = Base64.urlsafe_encode64(url)
-    image_tag qr_code_path(id), class: "qr-code center", alt: "QR Code"
+    qr_code_link = QrCodeLink.new(url)
+    image_tag qr_code_path(qr_code_link.signed), class: "qr-code center", alt: "QR Code"
   end
 end

--- a/app/models/qr_code_link.rb
+++ b/app/models/qr_code_link.rb
@@ -1,0 +1,26 @@
+class QrCodeLink
+  attr_reader :url
+
+  def initialize(url)
+    @url = url
+  end
+
+  def signed
+    self.class.verifier.generate(@url, purpose: :qr_code)
+  end
+
+  def self.from_signed(signed)
+    new verifier.verify(signed, purpose: :qr_code)
+  end
+
+  private
+    class << self
+      def verifier
+        ActiveSupport::MessageVerifier.new(secret)
+      end
+
+      def secret
+        Rails.application.key_generator.generate_key("qr_codes")
+      end
+    end
+end

--- a/test/models/qr_code_link_test.rb
+++ b/test/models/qr_code_link_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class QrCodeLinkTest < ActiveSupport::TestCase
+  test "links can be signed and verified" do
+    link = QrCodeLink.new "https://example.com"
+    signed_link = link.signed
+
+    verified = QrCodeLink.from_signed(signed_link)
+    assert_equal link.url, verified.url
+  end
+end


### PR DESCRIPTION
Prevents using the QR code link to create QR codes for arbitrary URLs, which could potentially be used in a phishing attack.

See https://3.basecamp.com/2914079/buckets/1666/card_tables/cards/7560511008
