### PR TITLE
Detect swipes to navigate forward

### DIFF
--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -24,7 +24,7 @@ module BooksHelper
 
   def link_to_first_leafable(leaves)
     if first_leaf = leaves.first
-      link_to leafable_slug_path(first_leaf), data: hotkey_data_attributes("right"), class: "disable-when-arranging", hidden: true do
+      link_to leafable_slug_path(first_leaf), data: { touch_target: "button" }.merge(hotkey_data_attributes("right")), class: "disable-when-arranging", hidden: true do
         tag.span(class: "btn") do
           image_tag("arrow-right.svg", aria: { hidden: true }, size: 24) + tag.span("Start reading", class: "for-screen-reader")
         end + tag.span(first_leaf.title, class: "overflow-ellipsis")
@@ -49,11 +49,11 @@ module BooksHelper
     if next_leaf = leaf.next
       path = for_edit ? edit_leafable_path(next_leaf) : leafable_slug_path(next_leaf)
       link_to path, data: hotkey_data_attributes("right", enabled: hotkey), class: "btn txt-medium min-width" do
-        tag.span("Next: #{next_leaf.title }", class: "overflow-ellipsis") + image_tag("arrow-right.svg", aria: { hidden: true }, size: 24)
+        tag.span("Next: #{next_leaf.title }", class: "overflow-ellipsis") + image_tag("arrow-right.svg", aria: { hidden: true }, size: 24, data: { touch_target: "button" })
       end
     else
       link_to book_slug_path(leaf.book), data: hotkey_data_attributes("right", enabled: hotkey), class: "btn txt-medium" do
-        tag.span("Table of contents: #{leaf.book.title }", class: "overflow-ellipsis") + image_tag("arrow-reverse.svg", aria: { hidden: true }, size: 24)
+        tag.span("Table of contents: #{leaf.book.title }", class: "overflow-ellipsis") + image_tag("arrow-reverse.svg", aria: { hidden: true }, size: 24, data: { touch_target: "button" })
       end
     end
   end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -24,7 +24,7 @@ module BooksHelper
 
   def link_to_first_leafable(leaves)
     if first_leaf = leaves.first
-      link_to leafable_slug_path(first_leaf), data: { touch_target: "button" }.merge(hotkey_data_attributes("right")), class: "disable-when-arranging", hidden: true do
+      link_to leafable_slug_path(first_leaf), data: hotkey_data_attributes("right"), class: "disable-when-arranging", hidden: true do
         tag.span(class: "btn") do
           image_tag("arrow-right.svg", aria: { hidden: true }, size: 24) + tag.span("Start reading", class: "for-screen-reader")
         end + tag.span(first_leaf.title, class: "overflow-ellipsis")
@@ -49,11 +49,11 @@ module BooksHelper
     if next_leaf = leaf.next
       path = for_edit ? edit_leafable_path(next_leaf) : leafable_slug_path(next_leaf)
       link_to path, data: hotkey_data_attributes("right", enabled: hotkey), class: "btn txt-medium min-width" do
-        tag.span("Next: #{next_leaf.title }", class: "overflow-ellipsis") + image_tag("arrow-right.svg", aria: { hidden: true }, size: 24, data: { touch_target: "button" })
+        tag.span("Next: #{next_leaf.title }", class: "overflow-ellipsis") + image_tag("arrow-right.svg", aria: { hidden: true }, size: 24)
       end
     else
       link_to book_slug_path(leaf.book), data: hotkey_data_attributes("right", enabled: hotkey), class: "btn txt-medium" do
-        tag.span("Table of contents: #{leaf.book.title }", class: "overflow-ellipsis") + image_tag("arrow-reverse.svg", aria: { hidden: true }, size: 24, data: { touch_target: "button" })
+        tag.span("Table of contents: #{leaf.book.title }", class: "overflow-ellipsis") + image_tag("arrow-reverse.svg", aria: { hidden: true }, size: 24)
       end
     end
   end
@@ -61,7 +61,7 @@ module BooksHelper
   private
     def hotkey_data_attributes(key, enabled: true)
       if enabled
-        { controller: "hotkey", action: "keydown.#{key}@document->hotkey#click" }
+        { controller: "hotkey", action: "keydown.#{key}@document->hotkey#click touch:swipe-#{key}@window->hotkey#click" }
       end
     end
 end

--- a/app/javascript/controllers/touch_controller.js
+++ b/app/javascript/controllers/touch_controller.js
@@ -3,8 +3,6 @@ import { Controller } from "@hotwired/stimulus"
 const SWIPE_THRESHOLD = 50
 
 export default class extends Controller {
-  static targets = ["button"]
-
   connect() {
     this.element.addEventListener("touchstart", this.#handleTouchStart.bind(this), false)
     this.element.addEventListener("touchend", this.#handleTouchEnd.bind(this), false)
@@ -23,12 +21,18 @@ export default class extends Controller {
 
     if (deltaX > SWIPE_THRESHOLD && deltaY < SWIPE_THRESHOLD) {
       if (this.startX > endX) {
-        this.#swipedForward()
+        this.#swipedRight()
+      } else {
+        this.#swipedLeft()
       }
     }
   }
 
-  #swipedForward() {
-    this.buttonTarget.click()
+  #swipedLeft() {
+    this.dispatch("swipe-left")
+  }
+
+  #swipedRight() {
+    this.dispatch("swipe-right")
   }
 }

--- a/app/javascript/controllers/touch_controller.js
+++ b/app/javascript/controllers/touch_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+const SWIPE_THRESHOLD = 50
+
+export default class extends Controller {
+  static targets = ["button"]
+
+  connect() {
+    this.element.addEventListener("touchstart", this.#handleTouchStart.bind(this), false)
+    this.element.addEventListener("touchend", this.#handleTouchEnd.bind(this), false)
+  }
+
+  #handleTouchStart(event) {
+    this.startX = event.touches[0].clientX
+    this.startY = event.touches[0].clientY
+  }
+
+  #handleTouchEnd(event) {
+    const endX = event.changedTouches[0].clientX
+    const endY = event.changedTouches[0].clientY
+    const deltaX = Math.abs(endX - this.startX)
+    const deltaY = Math.abs(endY - this.startY)
+
+    if (deltaX > SWIPE_THRESHOLD && deltaY < SWIPE_THRESHOLD) {
+      if (this.startX > endX) {
+        this.#swipedForward()
+      }
+    }
+  }
+
+  #swipedForward() {
+    this.buttonTarget.click()
+  }
+}

--- a/app/javascript/controllers/touch_controller.js
+++ b/app/javascript/controllers/touch_controller.js
@@ -14,6 +14,9 @@ export default class extends Controller {
   }
 
   #handleTouchEnd(event) {
+    console.log(this.#isSelection)
+    if (this.#isSelection) return
+
     const endX = event.changedTouches[0].clientX
     const endY = event.changedTouches[0].clientY
     const deltaX = Math.abs(endX - this.startX)
@@ -34,5 +37,10 @@ export default class extends Controller {
 
   #swipedRight() {
     this.dispatch("swipe-right")
+  }
+
+  get #isSelection() {
+    const selection = window.getSelection()
+    return selection.toString().length > 0 && !selection.isCollapsed
   }
 }

--- a/app/javascript/controllers/touch_controller.js
+++ b/app/javascript/controllers/touch_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
+const SWIPE_DURATION = 1000
 const SWIPE_THRESHOLD = 30
 
 export default class extends Controller {
@@ -11,10 +12,13 @@ export default class extends Controller {
   #handleTouchStart(event) {
     this.startX = event.touches[0].clientX
     this.startY = event.touches[0].clientY
+    this.startTime = new Date().getTime()
   }
 
   #handleTouchEnd(event) {
-    if (this.#isSelection) return
+    this.endTime = new Date().getTime()
+
+    if (this.#isSelection || this.#exceedsDuration) return
 
     const endX = event.changedTouches[0].clientX
     const endY = event.changedTouches[0].clientY
@@ -36,6 +40,11 @@ export default class extends Controller {
 
   #swipedRight() {
     this.dispatch("swipe-right")
+  }
+
+  get #exceedsDuration() {
+    const duration = this.endTime - this.startTime
+    return duration > SWIPE_DURATION
   }
 
   get #isSelection() {

--- a/app/javascript/controllers/touch_controller.js
+++ b/app/javascript/controllers/touch_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-const SWIPE_THRESHOLD = 50
+const SWIPE_THRESHOLD = 30
 
 export default class extends Controller {
   connect() {
@@ -14,7 +14,6 @@ export default class extends Controller {
   }
 
   #handleTouchEnd(event) {
-    console.log(this.#isSelection)
     if (this.#isSelection) return
 
     const endX = event.changedTouches[0].clientX

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body data-controller="fullscreen lightbox">
+  <body data-controller="fullscreen lightbox touch">
     <header id="header">
       <%= yield :header %>
     </header>


### PR DESCRIPTION
This is a proof-of-concept demonstrating that we can detect a right-to-left swipe on touch devices and use it to trigger the forward navigation button. 

There are a few things it might need...

1. Right now it blindly clicks and doesn't have preventions to keep it form triggering navigation when in edit mode like `hotkey_controller.js` does. Those could be duplicated here or maybe the touch events should be baked into `hotkey_controller.js`. 
2. Right now this only handles forward navigation because you get backward navigation for free when you swipe left-to-right from the screen edge. It may feel weird for one direction to work differently than the other but it also might be strange to hijack the swipe-to-go-back gesture with our custom one because it would feel unfamiliar. 
3. Right now it just happens, there is no visual indication that something happened other than the page changing. That may be fine but it makes it clear why the iOS implementation has an animated effect.

Want to take it for a spin?