### PR TITLE
lint: tell brakeman 7 to ignore the class eval in has_markdown

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dangerous Eval",
+      "warning_code": 13,
+      "fingerprint": "e150f325ca5214b108b537c408e52292bfcee725d435b6871a494068dd1b51c2",
+      "check_name": "Evaluation",
+      "message": "Dynamic string evaluated as code",
+      "file": "lib/rails_ext/action_text_has_markdown.rb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
+      "code": "class_eval(\"          def #{name}\\n            markdown_#{name} || build_markdown_#{name}\\n          end\\n\\n          def #{name}?\\n            markdown_#{name}.present?\\n          end\\n\\n          def #{name}=(content)\\n            self.#{name}.content = content\\n          end\\n\", \"lib/rails_ext/action_text_has_markdown.rb\", 8)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ActionText::HasMarkdown",
+        "method": "has_markdown"
+      },
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        913,
+        95
+      ],
+      "note": ""
+    }
+  ],
+  "brakeman_version": "7.0.0"
+}


### PR DESCRIPTION
This should have been part of #299