### PR TITLE
Use relative links for uploaded files

### DIFF
--- a/app/views/action_text/markdown/uploads/create.json.jbuilder
+++ b/app/views/action_text/markdown/uploads/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.message "File uploaded successfully"
 json.fileName @upload.filename.to_s
 json.mimetype @upload.content_type
-json.fileUrl @upload.slug_url host: request.host
+json.fileUrl @upload.slug_path

--- a/lib/rails_ext/active_storage_sluggable.rb
+++ b/lib/rails_ext/active_storage_sluggable.rb
@@ -5,8 +5,8 @@ module ActiveStorage::Sluggable
     before_create :set_slug
   end
 
-  def slug_url(host: ActiveStorage::Current.host)
-    Rails.application.routes.url_helpers.action_text_markdown_upload_url(slug, host: host)
+  def slug_path
+    Rails.application.routes.url_helpers.action_text_markdown_upload_path(slug)
   end
 
   private

--- a/test/controllers/action_text/markdown/uploads_controller_test.rb
+++ b/test/controllers/action_text/markdown/uploads_controller_test.rb
@@ -15,6 +15,9 @@ class ActionText::Markdown::UploadsControllerTest < ActionDispatch::IntegrationT
     end
 
     assert_response :success
+
+    # Uploads should use relative URLs, to allow for future hostname changes
+    assert JSON.parse(response.body)["fileUrl"].start_with?("/")
   end
 
   test "view attached file" do


### PR DESCRIPTION
Previously, uploading a file would generate an absolute URL, which then becomes part of the Markdown source. This creates problems if a site moves to a different hostname later, because all those absolute URL references in the Markdown content will now be wrong.

Instead, we should use relative URLs for these links, so they remain portable.

/cc @rosa 