### PR TITLE
Sanitize markdown output in edit history and TOC edit views

### DIFF
--- a/app/views/leaves/_edit.html.erb
+++ b/app/views/leaves/_edit.html.erb
@@ -6,7 +6,7 @@
 
   <%= link_to leafable_path(leaf), class: "toc__thumbnail", data: { turbo_frame: "_top" } do %>
     <%= leaf.section.body if leaf.section? %>
-    <%= leaf.leafable.body.to_html if leaf.page? %>
+    <%= sanitize_content(leaf.leafable.body.to_html) if leaf.page? %>
     <%= image_tag leaf.leafable.image.variant(:large) if leaf.picture&.image&.attached? %>
   <% end %>
 

--- a/app/views/pages/edits/show.html.erb
+++ b/app/views/pages/edits/show.html.erb
@@ -51,7 +51,7 @@
         <% end %>
       </header>
 
-      <%= @edit.page.body.to_html %>
+      <%= sanitize_content(@edit.page.body.to_html) %>
     <% end %>
   </section>
 
@@ -62,6 +62,6 @@
       <% end %>
     </header>
 
-    <%= @leaf.page.body.to_html %>
+    <%= sanitize_content(@leaf.page.body.to_html) %>
   </section>
 </div>

--- a/test/controllers/pages/edits_controller_test.rb
+++ b/test/controllers/pages/edits_controller_test.rb
@@ -23,4 +23,25 @@ class Pages::EditsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "p", /such a great handbook/
   end
+
+  test "show sanitizes dangerous content in previous version" do
+    leaf = books(:handbook).press Page.new(body: %(<img src=x onerror="alert(1)">)), title: "XSS Test"
+    leaf.edit leafable_params: { body: "Clean content now" }
+
+    get page_edit_url(leaf, leaf.edits.last)
+
+    assert_response :success
+    assert_match '<img src="x">', response.body
+    assert_no_match(/onerror/, response.body)
+  end
+
+  test "show sanitizes dangerous content in current version" do
+    leaves(:welcome_page).edit leafable_params: { body: %(<img src=x onerror="alert(1)">) }
+
+    get page_edit_url(leaves(:welcome_page), leaves(:welcome_page).edits.last)
+
+    assert_response :success
+    assert_match '<img src="x">', response.body
+    assert_no_match(/onerror/, response.body)
+  end
 end


### PR DESCRIPTION
The edit history view and TOC edit partial render Markdown content via to_html without passing through sanitize_content(), unlike the normal page view. This allows stored XSS via img onerror payloads for anyone who can view the edit history of a page with injected content.

Apply sanitize_content() consistently to all to_html output, matching the existing safe pattern in leafables/show.html.erb.