### PR TITLE
Allow changing default toc view, and disabling view selector

### DIFF
--- a/app/assets/stylesheets/toc.css
+++ b/app/assets/stylesheets/toc.css
@@ -248,6 +248,82 @@
   --btn-background: var(--color-link);
 }
 
+/* Forced view states when selector is disabled */
+.toc__container--force-list {
+  .toc {
+    display: flex;
+    flex-direction: column;
+    row-gap: calc(var(--block-space) * 0.3);
+  }
+
+  .toc__leaf {
+    align-items: center;
+    column-gap: 1ch;
+    flex-direction: row;
+    justify-content: center;
+    row-gap: calc(var(--block-space) * 0.3);
+    text-align: start;
+  }
+
+  .toc__title {
+    flex-direction: row;
+    flex-grow: 1;
+    font-size: inherit;
+    white-space: nowrap;
+
+    &:is(a) {
+      @media (hover: hover) {
+        &:hover {
+          text-decoration-line: underline;
+          text-decoration-thickness: 0.075em;
+        }
+      }
+    }
+
+    :is(.input) {
+      field-sizing: content;
+      min-inline-size: 20ch;
+    }
+
+    &::after {
+      border-block-end: 1px dotted var(--title-border-color);
+      content: "";
+      flex-grow: 1;
+      margin-block-end: 0.25em;
+    }
+
+    .toc__leaf--section & {
+      font-weight: 750;
+    }
+  }
+
+  .toc__thumbnail {
+    display: none;
+  }
+
+  .toc__wordcount {
+    font-size: 0.8em;
+  }
+}
+
+.toc__container--force-grid {
+  .toc__bookmark {
+    inset: calc(var(--icon-size) * -0.33) 0 auto calc(var(--icon-size) * -0.5);
+    position: absolute;
+  }
+
+  .toc__title {
+    font-weight: 700;
+  }
+
+  .leaf__delete .btn {
+    margin-block-end: calc(-0.5 * var(--btn-size));
+    margin-inline: auto;
+    position: relative;
+    z-index: 1;
+  }
+}
+
 body:not(:has(.toc__leaf)) {
   .disable-when-empty {
     cursor: not-allowed;

--- a/app/assets/stylesheets/toc.css
+++ b/app/assets/stylesheets/toc.css
@@ -20,7 +20,7 @@
     outline: none;
   }
 
-  .toc__container:where(:has(#toc-list:checked)) & {
+  .toc__container:where(:has(#toc-list:checked), .toc__container--force-list) & {
     display: flex;
     flex-direction: column;
     row-gap: calc(var(--block-space) * 0.3);
@@ -250,12 +250,6 @@
 
 /* Forced view states when selector is disabled */
 .toc__container--force-list {
-  .toc {
-    display: flex;
-    flex-direction: column;
-    row-gap: calc(var(--block-space) * 0.3);
-  }
-
   .toc__leaf {
     align-items: center;
     column-gap: 1ch;

--- a/app/assets/stylesheets/toc.css
+++ b/app/assets/stylesheets/toc.css
@@ -50,7 +50,7 @@
     display: inline-flex;
   }
 
-  .toc__container:where(:has(#toc-grid:checked)) & {
+  .toc__container:where(:has(#toc-grid:checked), .toc__container--force-grid) & {
     inset: calc(var(--icon-size) * -0.33) 0 auto calc(var(--icon-size) * -0.5);
     position: absolute;
   }
@@ -85,7 +85,7 @@
   scroll-margin-top: 8em;
   text-align: center;
 
-  .toc__container:where(:has(#toc-list:checked)) & {
+  .toc__container:where(:has(#toc-list:checked), .toc__container--force-list) & {
     align-items: center;
     column-gap: 1ch;
     flex-direction: row;
@@ -107,12 +107,12 @@
   text-decoration: none;
 
   .leaf--section &,
-  .toc__container:where(:has(#toc-grid:checked)) & {
+  .toc__container:where(:has(#toc-grid:checked), .toc__container--force-grid) & {
     font-weight: 700;
   }
 
   #sidebar &,
-  .toc__container:where(:has(#toc-list:checked)) & {
+  .toc__container:where(:has(#toc-list:checked), .toc__container--force-list) & {
     flex-direction: row;
     flex-grow: 1;
     font-size: inherit;
@@ -194,7 +194,7 @@
     }
   }
 
-  .toc__container:where(:has(#toc-list:checked)) & {
+  .toc__container:where(:has(#toc-list:checked), .toc__container--force-list) & {
     display: none;
   }
 
@@ -211,7 +211,7 @@
 .toc__wordcount {
   white-space: nowrap;
 
-  .toc__container:where(:has(#toc-list:checked)) & {
+  .toc__container:where(:has(#toc-list:checked), .toc__container--force-list) & {
     font-size: 0.8em;
   }
 }
@@ -232,7 +232,7 @@
     }
   }
 
-  .toc__container:where(:has(#toc-grid:checked)) & .btn {
+  .toc__container:where(:has(#toc-grid:checked), .toc__container--force-grid) & .btn {
     margin-block-end: calc(-0.5 * var(--btn-size));
     margin-inline: auto;
     position: relative;
@@ -246,76 +246,6 @@
 
 .arrange-mode__button:has(input:checked)  {
   --btn-background: var(--color-link);
-}
-
-/* Forced view states when selector is disabled */
-.toc__container--force-list {
-  .toc__leaf {
-    align-items: center;
-    column-gap: 1ch;
-    flex-direction: row;
-    justify-content: center;
-    row-gap: calc(var(--block-space) * 0.3);
-    text-align: start;
-  }
-
-  .toc__title {
-    flex-direction: row;
-    flex-grow: 1;
-    font-size: inherit;
-    white-space: nowrap;
-
-    &:is(a) {
-      @media (hover: hover) {
-        &:hover {
-          text-decoration-line: underline;
-          text-decoration-thickness: 0.075em;
-        }
-      }
-    }
-
-    :is(.input) {
-      field-sizing: content;
-      min-inline-size: 20ch;
-    }
-
-    &::after {
-      border-block-end: 1px dotted var(--title-border-color);
-      content: "";
-      flex-grow: 1;
-      margin-block-end: 0.25em;
-    }
-
-    .toc__leaf--section & {
-      font-weight: 750;
-    }
-  }
-
-  .toc__thumbnail {
-    display: none;
-  }
-
-  .toc__wordcount {
-    font-size: 0.8em;
-  }
-}
-
-.toc__container--force-grid {
-  .toc__bookmark {
-    inset: calc(var(--icon-size) * -0.33) 0 auto calc(var(--icon-size) * -0.5);
-    position: absolute;
-  }
-
-  .toc__title {
-    font-weight: 700;
-  }
-
-  .leaf__delete .btn {
-    margin-block-end: calc(-0.5 * var(--btn-size));
-    margin-inline: auto;
-    position: relative;
-    z-index: 1;
-  }
 }
 
 body:not(:has(.toc__leaf)) {

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -67,7 +67,7 @@ class BooksController < ApplicationController
     end
 
     def book_params
-      params.require(:book).permit(:title, :subtitle, :author, :cover, :remove_cover, :everyone_access, :theme)
+      params.require(:book).permit(:title, :subtitle, :author, :cover, :remove_cover, :everyone_access, :theme, :default_view, :allow_view_selector)
     end
 
     def update_accesses(book)

--- a/app/javascript/controllers/toc_view_controller.js
+++ b/app/javascript/controllers/toc_view_controller.js
@@ -3,7 +3,7 @@ import { readCookie, setCookie } from "helpers/cookie_helpers"
 
 export default class extends Controller {
   static targets = [ "switch" ]
-  static values = { id: String }
+  static values = { id: String, default: String }
 
   connect() {
     this.#restoreViewPref(this.idValue)
@@ -15,7 +15,7 @@ export default class extends Controller {
   }
 
   #restoreViewPref(id) {
-    const viewType = readCookie(id) || "grid"
+    const viewType = readCookie(id) || this.defaultValue
     this.switchTargets.forEach(switchTarget => {
       switchTarget.checked = switchTarget.dataset.tocViewTypeValue === viewType
     }

--- a/app/javascript/controllers/toc_view_controller.js
+++ b/app/javascript/controllers/toc_view_controller.js
@@ -18,6 +18,6 @@ export default class extends Controller {
     const viewType = readCookie(id) || this.defaultValue
     this.switchTargets.forEach(switchTarget => {
       switchTarget.checked = switchTarget.dataset.tocViewTypeValue === viewType
-    }
-  )}
+    })
+  }
 }

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,6 +8,7 @@ class Book < ApplicationRecord
   scope :published, -> { where(published: true) }
 
   enum :theme, %w[ black blue green magenta orange violet white ].index_by(&:itself), suffix: true, default: :blue
+  enum :default_view, %w[ list grid ].index_by(&:itself), suffix: true, default: :grid
 
   def press(leafable, leaf_params)
     leaves.create! leaf_params.merge(leafable: leafable)

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -59,6 +59,46 @@
     </div>
   </div>
 
+  <div class="book-view-settings border-radius center pad-double fill-shade flex flex-column gap margin-block-double">
+    <div class="flex align-center gap txt-medium--responsive">
+      <%= image_tag "view-grid.svg", aria: { hidden: true }, size: 36, class: "colorize--black" %>
+
+      <div class="min-width">
+        <div class="overflow-ellipsis fill-shade"><strong>Default view</strong></div>
+      </div>
+
+      <hr class="flex-item-grow margin-none" aria-hidden="true" style="--border-style: dashed">
+
+      <div class="flex gap-half">
+        <% Book.default_views.keys.each do |view| %>
+          <label class="btn txt-small" title="<%= view.capitalize %> view">
+            <%= form.radio_button :default_view, view %>
+            <%= image_tag "view-#{view}.svg", aria: { hidden: true }, size: 20 %>
+            <span class="for-screen-reader"><%= view.capitalize %> view</span>
+          </label>
+        <% end %>
+      </div>
+    </div>
+
+    <hr class="full-width margin-block-start margin-block-end-half">
+
+    <div class="flex align-center gap txt-medium--responsive">
+      <%= image_tag "settings.svg", aria: { hidden: true }, size: 36, class: "colorize--black" %>
+
+      <div class="min-width">
+        <div class="overflow-ellipsis fill-shade"><strong>View selector</strong></div>
+      </div>
+
+      <hr class="flex-item-grow margin-none" aria-hidden="true" style="--border-style: dashed">
+
+      <label for="book_allow_view_selector" class="switch">
+        <%= form.check_box :allow_view_selector, class: "switch__input book-access__switch" %>
+        <span class="switch__btn"></span>
+        <span class="for-screen-reader">Allow users to switch between list and grid view</span>
+      </label>
+    </div>
+  </div>
+
   <div class="book-access border-radius center pad-double fill-shade flex flex-column gap margin-block-double">
     <div class="flex align-center gap txt-medium--responsive">
       <%= image_tag "eye.svg", aria: { hidden: true }, size: 36, class: "colorize--black" %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -83,13 +83,13 @@
     <div class="book__toolbar fill-white flex gap-half pad-block margin-block-end-half justify-center <%= "position-sticky" if @book.editable? %>" data-controller="toc-view" data-toc-view-id-value="<%= dom_id(@book) %>" data-toc-view-default-value="<%= @book.default_view %>">
       <% if @book.allow_view_selector? %>
         <label class="btn txt-medium disable-when-empty">
-          <input type="radio" name="view" id="toc-list" value="list" data-toc-view-target="switch" data-toc-view-type-value="list" data-action="toc-view#saveViewPref">
+          <input type="radio" name="view" id="toc-list" value="list" data-toc-view-target="switch" data-toc-view-type-value="list" data-action="toc-view#saveViewPref"<%= ' checked="checked"' if @book.default_view == 'list' %>>
           <%= image_tag "view-list.svg", aria: { hidden: true }, size: 24 %>
           <span class="for-screen-reader">List view</span>
         </label>
 
         <label class="btn txt-medium flex-item-justify-start disable-when-empty">
-          <input type="radio" name="view" id="toc-grid" value="grid" data-toc-view-target="switch" data-toc-view-type-value="grid" data-action="toc-view#saveViewPref">
+          <input type="radio" name="view" id="toc-grid" value="grid" data-toc-view-target="switch" data-toc-view-type-value="grid" data-action="toc-view#saveViewPref"<%= ' checked="checked"' if @book.default_view == 'grid' %>>
           <%= image_tag "view-grid.svg", aria: { hidden: true }, size: 24 %>
           <span class="for-screen-reader">Page view</span>
         </label>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -73,25 +73,27 @@
     </div>
   </aside>
 
-  <%= arrangement_tag @book, class: "arrangement__container toc__container full-width txt-align-center" do %>
+  <%= arrangement_tag @book, class: "arrangement__container toc__container full-width txt-align-center #{'toc__container--force-' + @book.default_view unless @book.allow_view_selector?}" do %>
     <h1 class="flex flex-column txt-tight-lines txt-align-start margin-block-end">
       <strong class="book__title txt-x-large--responsive"><%= @book.title %></strong>
       <span class="txt-large--responsive txt-normal"><%= @book.subtitle %></span>
       <span class="txt-large--responsive txt-normal"><%= @book.author %></span>
     </h1>
 
-    <div class="book__toolbar fill-white flex gap-half pad-block margin-block-end-half justify-center <%= "position-sticky" if @book.editable? %>" data-controller="toc-view" data-toc-view-id-value="<%= dom_id(@book) %>">
-      <label class="btn txt-medium disable-when-empty">
-        <input type="radio" name="view" id="toc-list" value="list" data-toc-view-target="switch" data-toc-view-type-value="list" data-action="toc-view#saveViewPref">
-        <%= image_tag "view-list.svg", aria: { hidden: true }, size: 24 %>
-        <span class="for-screen-reader">List view</span>
-      </label>
+    <div class="book__toolbar fill-white flex gap-half pad-block margin-block-end-half justify-center <%= "position-sticky" if @book.editable? %>" data-controller="toc-view" data-toc-view-id-value="<%= dom_id(@book) %>" data-toc-view-default-value="<%= @book.default_view %>">
+      <% if @book.allow_view_selector? %>
+        <label class="btn txt-medium disable-when-empty">
+          <input type="radio" name="view" id="toc-list" value="list" data-toc-view-target="switch" data-toc-view-type-value="list" data-action="toc-view#saveViewPref">
+          <%= image_tag "view-list.svg", aria: { hidden: true }, size: 24 %>
+          <span class="for-screen-reader">List view</span>
+        </label>
 
-      <label class="btn txt-medium flex-item-justify-start disable-when-empty">
-        <input type="radio" name="view" id="toc-grid" value="grid" checked="checked" data-toc-view-target="switch" data-toc-view-type-value="grid" data-action="toc-view#saveViewPref">
-        <%= image_tag "view-grid.svg", aria: { hidden: true }, size: 24 %>
-        <span class="for-screen-reader">Page view</span>
-      </label>
+        <label class="btn txt-medium flex-item-justify-start disable-when-empty">
+          <input type="radio" name="view" id="toc-grid" value="grid" data-toc-view-target="switch" data-toc-view-type-value="grid" data-action="toc-view#saveViewPref">
+          <%= image_tag "view-grid.svg", aria: { hidden: true }, size: 24 %>
+          <span class="for-screen-reader">Page view</span>
+        </label>
+      <% end %>
 
       <% if @book.editable? %>
         <%= render "books/create_buttons", book: @book %>

--- a/db/migrate/20260317235838_add_view_settings_to_books.rb
+++ b/db/migrate/20260317235838_add_view_settings_to_books.rb
@@ -1,0 +1,6 @@
+class AddViewSettingsToBooks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :books, :default_view, :string, default: "grid", null: false
+    add_column :books, :allow_view_selector, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,42 +10,42 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_09_28_005927) do
+ActiveRecord::Schema[8.2].define(version: 2026_03_17_235838) do
   create_table "accesses", force: :cascade do |t|
-    t.integer "user_id", null: false
     t.integer "book_id", null: false
-    t.string "level", null: false
     t.datetime "created_at", null: false
+    t.string "level", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
     t.index ["book_id"], name: "index_accesses_on_book_id"
     t.index ["user_id", "book_id"], name: "index_accesses_on_user_id_and_book_id", unique: true
     t.index ["user_id"], name: "index_accesses_on_user_id"
   end
 
   create_table "accounts", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "join_code", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.text "custom_styles"
+    t.string "join_code", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "action_text_markdowns", force: :cascade do |t|
-    t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.string "name", null: false
     t.text "content", default: "", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.integer "record_id", null: false
+    t.string "record_type", null: false
     t.datetime "updated_at", null: false
     t.index ["record_type", "record_id"], name: "index_action_text_markdowns_on_record"
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.string "slug"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -53,14 +53,14 @@ ActiveRecord::Schema[8.0].define(version: 2024_09_28_005927) do
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -71,24 +71,26 @@ ActiveRecord::Schema[8.0].define(version: 2024_09_28_005927) do
   end
 
   create_table "books", force: :cascade do |t|
-    t.string "title", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "subtitle"
+    t.boolean "allow_view_selector", default: true, null: false
     t.string "author"
+    t.datetime "created_at", null: false
+    t.string "default_view", default: "grid", null: false
+    t.boolean "everyone_access", default: true, null: false
     t.boolean "published", default: false, null: false
     t.string "slug", null: false
-    t.boolean "everyone_access", default: true, null: false
+    t.string "subtitle"
     t.string "theme", default: "blue", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
     t.index ["published"], name: "index_books_on_published"
   end
 
   create_table "edits", force: :cascade do |t|
-    t.integer "leaf_id", null: false
-    t.string "leafable_type", null: false
-    t.integer "leafable_id", null: false
     t.string "action", null: false
     t.datetime "created_at", null: false
+    t.integer "leaf_id", null: false
+    t.integer "leafable_id", null: false
+    t.string "leafable_type", null: false
     t.datetime "updated_at", null: false
     t.index ["leaf_id"], name: "index_edits_on_leaf_id"
     t.index ["leafable_type", "leafable_id"], name: "index_edits_on_leafable"
@@ -96,13 +98,13 @@ ActiveRecord::Schema[8.0].define(version: 2024_09_28_005927) do
 
   create_table "leaves", force: :cascade do |t|
     t.integer "book_id", null: false
-    t.string "leafable_type", null: false
+    t.datetime "created_at", null: false
     t.integer "leafable_id", null: false
+    t.string "leafable_type", null: false
     t.float "position_score", null: false
     t.string "status", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "title", null: false
+    t.datetime "updated_at", null: false
     t.index ["book_id"], name: "index_leaves_on_book_id"
     t.index ["leafable_type", "leafable_id"], name: "index_leafs_on_leafable"
   end
@@ -113,37 +115,37 @@ ActiveRecord::Schema[8.0].define(version: 2024_09_28_005927) do
   end
 
   create_table "pictures", force: :cascade do |t|
+    t.string "caption"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "caption"
   end
 
   create_table "sections", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "theme"
     t.text "body"
+    t.datetime "created_at", null: false
+    t.string "theme"
+    t.datetime "updated_at", null: false
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "token", null: false
-    t.string "ip_address"
-    t.string "user_agent"
-    t.datetime "last_active_at", null: false
     t.datetime "created_at", null: false
+    t.string "ip_address"
+    t.datetime "last_active_at", null: false
+    t.string "token", null: false
     t.datetime "updated_at", null: false
+    t.string "user_agent"
+    t.integer "user_id", null: false
     t.index ["token"], name: "index_sessions_on_token", unique: true
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "email_address", null: false
-    t.string "password_digest", null: false
-    t.integer "role", null: false
     t.boolean "active", default: true
     t.datetime "created_at", null: false
+    t.string "email_address", null: false
+    t.string "name", null: false
+    t.string "password_digest", null: false
+    t.integer "role", null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -114,4 +114,49 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "link[rel=\"alternate\"][type=\"text/markdown\"][href=\"#{book_slug_path(books(:handbook), format: :md)}\"]"
   end
+
+  test "update persists view settings" do
+    book = books(:handbook)
+
+    patch book_path(book), params: { book: { default_view: "list", allow_view_selector: false } }
+
+    assert_redirected_to book_slug_path(book)
+    book.reload
+    assert_equal "list", book.default_view
+    assert_not book.allow_view_selector?
+  end
+
+  test "show hides view selector when disabled" do
+    book = books(:handbook)
+    book.update!(allow_view_selector: false)
+
+    get book_slug_path(book)
+
+    assert_response :success
+    assert_not_in_body "List view"
+    assert_not_in_body "Page view"
+    assert_not_in_body "view-list"
+    assert_not_in_body "view-grid"
+  end
+
+  test "show applies forced view class when selector is disabled" do
+    book = books(:handbook)
+    book.update!(allow_view_selector: false, default_view: "list")
+
+    get book_slug_path(book)
+
+    assert_response :success
+    assert_in_body "toc__container--force-list"
+  end
+
+  test "show shows view selector when enabled" do
+    book = books(:handbook)
+    book.update!(allow_view_selector: true)
+
+    get book_slug_path(book)
+
+    assert_response :success
+    assert_in_body "List view"
+    assert_in_body "Page view"
+  end
 end

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -40,4 +40,15 @@ class BookTest < ActiveSupport::TestCase
   test "markable returns empty string for book with no leaves" do
     assert_equal "", books(:manual).markable
   end
+
+  test "default_view defaults to grid" do
+    book = Book.create!(title: "Test Book")
+    assert_equal "grid", book.default_view
+    assert book.grid_default_view?
+  end
+
+  test "allow_view_selector defaults to true" do
+    book = Book.create!(title: "Test Book")
+    assert book.allow_view_selector?
+  end
 end


### PR DESCRIPTION
This pull request introduces configurable view settings for books, allowing admins to set a default view (list or grid) and control whether users can switch between views.

The existing behavior with having a view selector with `grid` as default is preserved.

## Motivation

Give authors a way of showing their publications in their preferred way, either as with a default or enforced (no view selector).

## Changes
- Migration adds `default_view` (default: "grid") and `allow_view_selector` (default: true) columns to books
- Updates book form with radio buttons for default view selection and toggle for view selector visibility
- Conditionally renders view selector UI based on `allow_view_selector?` setting
- CSS classes force the selected view when selector is disabled
- JavaScript uses book's default view instead of hardcoded "grid"
- Adds tests for updated model and controller

## Screenshots

<details>
<summary>Screenshots - expand to show</summary>

Book settings:
<img width="783" height="886" alt="image" src="https://github.com/user-attachments/assets/ad8e23db-6562-4d9d-b09a-d196d02eb95a" />

Reader view with `allow_view_selector`:`false` and `default_view`: `grid`
<img width="943" height="696" alt="image" src="https://github.com/user-attachments/assets/60ab38a3-0a91-428b-b8d7-8daaf5760ba6" />


Reader view with `allow_view_selector`:`false` and `default_view`: `list`
<img width="943" height="696" alt="image" src="https://github.com/user-attachments/assets/fe7975da-04a9-4821-84a8-74c55743c7d9" />

Reader view with default settings (`allow_view_selector`:`true` and `default_view`: `grid`)
<img width="943" height="696" alt="image" src="https://github.com/user-attachments/assets/86fa9fba-e1fe-45ec-a360-ff89f432c537" />

</details>
