### PR TITLE
Upgrade puma to 7.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "sqlite3", "~> 2.9"
 gem "redis", ">= 4.0.1"
 
 # Deployment
-gem "puma", ">= 5.0"
+gem "puma", "~> 7.2", ">= 7.2.1"
 
 # Jobs
 gem "resque", "~> 2.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -387,7 +387,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   propshaft
-  puma (>= 5.0)
+  puma (~> 7.2, >= 7.2.1)
   rails!
   redcarpet (~> 3.6)
   redis (>= 4.0.1)


### PR DESCRIPTION
## Summary

Upgrade puma from 6.6.0 to 7.2.1 to fix vulnerabilities.

Major version bump (6 → 7) analyzed across **166 upstream commits** (v6.6.0..v7.2.1). **0 mitigations** required — writebook uses a minimal, standard Puma config and standard Rack/Rails integration. **No transitive dependency changes** (puma-only bump).

## Version constraint

Gemfile constraint changed from `">= 5.0"` to `"~> 7.2", ">= 7.2.1"`:
- Floors at the security fix (7.2.1).
- Caps below 8.x, which is **outside the analyzed range** (recon covered only v6.6.0..v7.2.1). A plain `bundle update puma` floats to 8.0.2.

## Verification

- `bin/rails test` → 159 runs, 522 assertions, **0 failures/errors**.
- `bin/rails test:system` → 2 runs, 8 assertions, **0 failures/errors**. Capybara booted Puma 7.2.1 cleanly, confirming the Capybara→Puma boot path (the one "definite impact" verification point).

## Breaking changes in range — all confirmed NOT to affect writebook

- Min Ruby now 3.0 (app runs 3.4.7).
- Response headers emitted lowercase — no case-sensitive header assertions.
- `Puma::Events#fire_on_*!` renamed + config-load enforcement — app references no Puma internals.
- `env['HTTP_VERSION']` dropped for Rack > 3.1 — Rails reads `SERVER_PROTOCOL` first.
- `rack.hijack` → `full_hijack` — ActionCable uses the standard `.call` contract.

## Post-deploy verification points (no code change)

- Confirm Thruster idle timeout (~60s) still sits below Puma 7's new 65s `persistent_timeout` default.
- Glance at p50/p99 latency under keep-alive load after deploy.

## Upgrade plan

Full analysis posted as a PR comment below; archived at `37signals-hq/upgrade-analysis/writebook-20260609-puma_v6.6.0..v7.2.1.md`.

🤖 Assisted by Claude