### PR TITLE
Upgrade crass to 1.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     chunky_png (1.4.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.10.0)
       irb (~> 1.10)


### PR DESCRIPTION
## Summary

Upgrade crass 1.0.6 → 1.0.7 (transitive, via loofah). Closes four DoS-hardening fixes in crass's CSS tokenizer/parser (GHSA-6wmf-3r64-vcwv, GHSA-wwpr-jff3-395c, GHSA-8vfg-2r28-hvhj, GHSA-6jxj-px6v-747w).

No application code changes — pure lockfile bump. bc3 and fizzy already run 1.0.7 in production. Full analysis posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
