### PR TITLE
Add static site generator with client-side search

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ### Instantly publish your own books on the web for free, no publisher required.
 
+> **This is a fork of [basecamp/writebook](https://github.com/basecamp/writebook)**
+> that adds a **static site generator**: export the public library to a
+> self-contained static HTML site you can host anywhere — no Rails process,
+> login, or editing machinery. See **[STATIC_SITE_GENERATOR.md](./STATIC_SITE_GENERATOR.md)**
+> for the full guide, or the quick summary below.
+
 Writebook is an easy-to-use application for publishing content on the web.
 Content is authored in Markdown, and books can contain picture pages, chapters, and title pages.
 Books can be published privately or publicly, and are searchable.
@@ -43,3 +49,24 @@ Start the development server:
 ```sh
 bin/dev
 ```
+
+## Static site generator (this fork)
+
+Render the published library to a static HTML directory you can host anywhere —
+all books, every page, all CSS/JS and image files copied in, no login or editing
+machinery.
+
+**From the admin UI:** an admin-only **Export to static site** button in the
+library header runs the export and shows a result page with the file counts and
+what to do next (where the files are, how to preview locally, how to deploy).
+
+**From the command line:**
+
+```sh
+bin/rails static:generate                                  # → tmp/static-site
+STATIC_HOST=books.example.com bin/rails static:generate    # absolute URLs → this host
+STATIC_ALL=1 bin/rails static:generate                      # include unpublished books (DB untouched)
+```
+
+See **[STATIC_SITE_GENERATOR.md](./STATIC_SITE_GENERATOR.md)** for what's
+included, the design principles, and the file map.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,14 @@ all books, every page, all CSS/JS and image files copied in, no login or editing
 machinery.
 
 **From the admin UI:** an admin-only **Export to static site** button in the
-library header runs the export and shows a result page with the file counts and
-what to do next (where the files are, how to preview locally, how to deploy).
+library header opens a landing page where you pick a scope — **all published
+books** (optionally including unpublished drafts) or **a single book** to export
+by itself. It runs the export and shows a result page with the file counts and
+what to do next (where the files are, how to preview locally, how to deploy),
+plus a **Download .zip** button (`writebook-static-site.zip`, or
+`writebook-<slug>.zip` for a single book) and a **Preview site** button. The
+live database is never touched — the export runs inside a rolled-back
+transaction.
 
 **From the command line:**
 

--- a/STATIC_SITE_GENERATOR.md
+++ b/STATIC_SITE_GENERATOR.md
@@ -137,7 +137,7 @@ The two faithful post-processing additions:
 bin/rails test
 ```
 
-All green: 171 runs, 597 assertions, 0 failures.
+All green: 186 runs, 709 assertions, 0 failures.
 
 ## Credits
 

--- a/STATIC_SITE_GENERATOR.md
+++ b/STATIC_SITE_GENERATOR.md
@@ -1,0 +1,130 @@
+# Static site generator
+
+This fork of [basecamp/writebook](https://github.com/basecamp/writebook) adds a
+**static site generator**: it renders the public library — the menu of books,
+every book's table of contents, and every leaf — to a self-contained static HTML
+directory you can host anywhere, with **no Rails process, login, or editing
+machinery**. All CSS/JS assets and image binaries (covers, in-body uploads,
+ActiveStorage pictures) are copied in.
+
+It's a generic feature for the OSS Writebook project — intended to be PR-able
+upstream to Basecamp — and is not coupled to any one instance. Any operator can
+export their own books from their own Writebook.
+
+## Two ways to run
+
+### From the admin UI (synchronous)
+
+Administrators get a new **Export to static site** button (the download icon) in
+the library page header. It opens a landing page; clicking **Generate static
+site** runs the export into `tmp/static-site` and shows a result page with the
+counts and **what to do next**:
+
+- where the files are on the server,
+- how to preview locally (`cd tmp/static-site && python3 -m http.server 8080`),
+- how to deploy — copy the directory's contents to any static host (Netlify,
+  Cloudflare Pages, GitHub Pages, an S3 bucket, nginx); URLs are root-relative so
+  the site works at any domain's root with no extra config.
+
+The export runs synchronously. Writebook runs no background jobs, and a
+published-only export takes seconds. For very large libraries the result page
+points you at the rake task below, to avoid holding a single web request open.
+
+### From the command line
+
+```sh
+# Export published books to tmp/static-site:
+bin/rails static:generate
+
+# Custom output directory:
+bin/rails static:generate[path/to/output]
+
+# Absolute URLs are rewritten to this host, then made root-relative:
+STATIC_HOST=books.example.com bin/rails static:generate
+
+# Include unpublished books too — the live DB is left untouched:
+STATIC_ALL=1 bin/rails static:generate
+```
+
+`STATIC_ALL=1` temporarily flips `published: true` inside a rolled-back
+`Book.transaction`, so unpublished drafts render but the live database is never
+modified.
+
+## What's included
+
+- The library menu (`/`), every book (`/:id/:slug`), and every leaf
+  (`/:book_id/:book_slug/:id/:slug`).
+- The library cards' bookmark overlay frames (`/books/:id/bookmark`), rendered
+  so the cards' click targets resolve on the static host instead of 404ing into
+  Turbo's "content missing" fallback.
+- The front-matter **markdown** alternate routes (`….md`) the book and leaf
+  views declare via `<link rel="alternate" type="text/markdown">`.
+- Every precompiled asset in `public/assets/`, the root static files
+  (`favicon.svg`, `app-icon.png`, `robots.txt`, …), and the PWA manifest.
+- Every referenced image blob — ActiveStorage covers/pictures
+  (`/rails/active_storage/…`) and in-body uploads (`/u/<slug>`).
+- The per-book table-of-contents sidebar, externalized once per book and loaded
+  with a tiny inline fetch (see Design below).
+
+## What's NOT included
+
+- **Editing/auth machinery.** The read templates already suppress every editing
+  affordance when `book.editable?` is false (i.e. logged-out), so **no application
+  code is modified** — the same templates produce clean read-only HTML. The one
+  login affordance that remains in the logged-out view (the library's sign-in
+  link) is stripped from the output, since it has no destination on a static host.
+- **Unpublished books**, by default. Use `STATIC_ALL=1`.
+
+## Design principles
+
+- **Render every route the read views reference — nothing more, nothing less.**
+  The exporter drives `ActionDispatch::Integration::Session`, so every read-view
+  helper (`arrangement_tag`, `leaf_nav_tag`, `link_to_next_leafable`,
+  `page.body.to_html`, …) runs in its real request context — no stubbing. Read
+  views are rendered logged-out, exactly as a visitor sees them.
+- **No template changes.** All transforms are post-processing on rendered HTML.
+- **Keep the reading UX faithful.** Turbo Drive, Turbo Frames, and the Stimulus
+  controllers (hotkey nav, lightbox, sidebar, reading-tracker, toc-view, …) ship
+  exactly as Writebook provides them. The only JS the exporter adds is the
+  one-line sidebar fetch.
+
+The two faithful post-processing additions:
+
+1. **Bookmark frames.** Rewrite each library card's
+   `<turbo-frame src="/books/:id/bookmark">` to a trailing slash and render
+   `/books/:id/bookmark/` to `books/:id/bookmark/index.html`, so the overlay
+   click target resolves.
+2. **Externalize the sidebar.** The full book TOC is byte-identical across every
+   leaf. Writing it once per book (`<book_rel>/_sidebar.html`) and loading it with
+   a small inline `fetch("../../_sidebar.html")` turns an O(n²) export (every leaf
+   carries the whole TOC) into O(n). With JS off the sidebar nav is absent, but
+   the page body and prev/next still work. A 1,255-leaf book goes from ~390 MB to
+   ~39 MB.
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `lib/writebook/static_exporter.rb` | `Writebook::StaticExporter` — the renderer |
+| `lib/tasks/static.rake` | `bin/rails static:generate` |
+| `app/controllers/static_exports_controller.rb` | Admin UI action (`show` landing, `create` runs the export; `before_action :ensure_can_administer`) |
+| `app/views/static_exports/show.html.erb` | Landing page with the Generate button |
+| `app/views/static_exports/create.html.erb` | Result page with counts + next steps |
+| `app/views/books/index.html.erb` | Admin download button in the library header |
+| `config/routes.rb` | `resource :static_export` |
+| `test/lib/writebook/static_exporter_test.rb` | Exporter tests |
+| `test/controllers/static_exports_controller_test.rb` | UI controller tests |
+
+## Running the tests
+
+```sh
+bin/rails test
+```
+
+All green: 171 runs, 597 assertions, 0 failures.
+
+## Credits
+
+Built on [basecamp/writebook](https://github.com/basecamp/writebook)
+(MIT-licensed). This static-site-generator feature is intended as an upstream
+contribution.

--- a/STATIC_SITE_GENERATOR.md
+++ b/STATIC_SITE_GENERATOR.md
@@ -16,9 +16,17 @@ export their own books from their own Writebook.
 ### From the admin UI (synchronous)
 
 Administrators get a new **Export to static site** button (the download icon) in
-the library page header. It opens a landing page; clicking **Generate static
-site** runs the export into `tmp/static-site` and shows a result page with the
-counts and **what to do next**:
+the library page header. It opens a landing page with a selector:
+
+- **All published books** — export the whole library. Check **Include
+  unpublished drafts** to also render books that aren't published yet.
+- **A single book** — pick one title to export by itself, handy for sharing or
+  hosting one book at a time. The chosen book is exported whether or not it's
+  published; the drafts checkbox only applies to the whole-library export. The
+  generated site's library menu lists just that one book.
+
+Clicking **Generate static site** runs the export into `tmp/static-site` and
+shows a result page with the counts and **what to do next**:
 
 - where the files are on the server,
 - how to preview locally (`cd tmp/static-site && python3 -m http.server 8080`),
@@ -26,9 +34,17 @@ counts and **what to do next**:
   Cloudflare Pages, GitHub Pages, an S3 bucket, nginx); URLs are root-relative so
   the site works at any domain's root with no extra config.
 
+From there, **Download .zip** streams the generated site as a single archive
+(named `writebook-static-site.zip`, or `writebook-<slug>.zip` when you exported
+one book), and **Preview site** serves it from inside the app under
+`/static-site/` so you can see it rendered in a browser tab.
+
 The export runs synchronously. Writebook runs no background jobs, and a
 published-only export takes seconds. For very large libraries the result page
 points you at the rake task below, to avoid holding a single web request open.
+
+Either scope is rolled back the moment the export finishes, so your live
+database is never touched — the same approach the rake task uses.
 
 ### From the command line
 

--- a/app/controllers/static_exports_controller.rb
+++ b/app/controllers/static_exports_controller.rb
@@ -12,18 +12,21 @@ class StaticExportsController < ApplicationController
 
   # Renders the published library to tmp/static-site (the same default the
   # static:generate rake task uses) and shows the result with hosting steps.
-  # Synchronous -- Writebook runs no background jobs, and a published-only
-  # export takes seconds. Operators with very large libraries should use the
-  # rake task instead (noted on the result page) to avoid a request timeout.
+  # Pass include_drafts=1 to also export unpublished books (rolled back so the
+  # live database is untouched). Synchronous -- a published-only export takes
+  # seconds; operators with very large libraries should use the rake task
+  # instead (noted on the landing page) to avoid a request timeout.
   def create
     @output_dir = static_dir.expand_path
+    include_drafts = params[:include_drafts] == "1"
 
     # Nothing to render: the library root itself redirects when there are no
     # published books, so short-circuit before the exporter would hit that.
-    if Book.published.none?
+    # (With drafts requested, an empty library -- no books at all -- is the same.)
+    if include_drafts ? Book.none? : Book.published.none?
       render :empty
     else
-      @result = generate
+      @result = generate(include_drafts: include_drafts)
       render :create
     end
   end
@@ -59,12 +62,39 @@ class StaticExportsController < ApplicationController
       Rails.root.join("tmp/static-site")
     end
 
-    def generate
-      Writebook::StaticExporter.new(
-        static_dir,
-        host: request.host,
-        protocol: request.ssl? ? "https" : "http"
-      ).call
+    # Runs the exporter. The work is done in a separate thread wrapped in the
+    # Rails executor: the exporter renders every page through a nested
+    # ActionDispatch::Integration::Session, which re-enters the middleware
+    # stack and resets ActiveSupport::CurrentAttributes. Running that nested
+    # session inside the live request's thread would wipe the request's own
+    # Current (and break the layout's `signed_in?`), so it runs in a thread
+    # with its own CurrentAttributes scope instead. The thread is joined so the
+    # request still returns the result synchronously.
+    #
+    # When include_drafts is set, unpublished books are temporarily published
+    # inside a rolled-back transaction so the exporter renders them and the live
+    # database is left untouched -- the same approach as `bin/rails static:generate
+    # STATIC_ALL=1`.
+    def generate(include_drafts: false)
+      host = request.host
+      protocol = request.ssl? ? "https" : "http"
+      exporter = -> { Writebook::StaticExporter.new(static_dir, host: host, protocol: protocol).call }
+
+      result = nil
+      Thread.new do
+        Rails.application.executor.wrap do
+          if include_drafts
+            Book.transaction do
+              Book.where(published: [false, nil]).update_all(published: true)
+              result = exporter.call
+              raise ActiveRecord::Rollback
+            end
+          else
+            result = exporter.call
+          end
+        end
+      end.join
+      result
     end
 
     # Build the static site only when it isn't already on disk, so a direct hit

--- a/app/controllers/static_exports_controller.rb
+++ b/app/controllers/static_exports_controller.rb
@@ -16,14 +16,94 @@ class StaticExportsController < ApplicationController
   # export takes seconds. Operators with very large libraries should use the
   # rake task instead (noted on the result page) to avoid a request timeout.
   def create
-    dir = Rails.root.join("tmp/static-site")
-    @result = Writebook::StaticExporter.new(
-      dir,
-      host: request.host,
-      protocol: request.ssl? ? "https" : "http"
-    ).call
-    @output_dir = dir
+    @output_dir = static_dir.expand_path
 
-    render :create
+    # Nothing to render: the library root itself redirects when there are no
+    # published books, so short-circuit before the exporter would hit that.
+    if Book.published.none?
+      render :empty
+    else
+      @result = generate
+      render :create
+    end
   end
+
+  # Streams the generated site as a single .zip the operator can download from
+  # the browser -- no server shell needed. Reuses the directory #create built;
+  # regenerates first if it's absent (e.g. the operator bookmarked this URL).
+  def download
+    ensure_static_site_generated
+    send_file zip_static_site, filename: "writebook-static-site.zip",
+               type: "application/zip", disposition: "attachment"
+  end
+
+  # Serves the generated site from inside the running app so the operator can
+  # see the export rendered in a browser tab without a server shell or a
+  # separate web server. The directory is mapped under /static-site/ and any
+  # path traversal is rejected.
+  #
+  # The static HTML uses root-relative URLs (/assets/..., /u/..., /rails/...).
+  # Those resolve against the live app when the preview is served from a
+  # subpath -- which is what we want, since the live app serves the same
+  # precompiled assets and the same image blobs the export copied. The relative
+  # sidebar fetch (../../_sidebar.html) and per-book files resolve within
+  # /static-site/ and are served from the directory. The header CSP is cleared
+  # so the static HTML's own <meta> policy governs, just like a real static host.
+  def preview
+    ensure_static_site_generated
+    serve_preview_file
+  end
+
+  private
+    def static_dir
+      Rails.root.join("tmp/static-site")
+    end
+
+    def generate
+      Writebook::StaticExporter.new(
+        static_dir,
+        host: request.host,
+        protocol: request.ssl? ? "https" : "http"
+      ).call
+    end
+
+    # Build the static site only when it isn't already on disk, so a direct hit
+    # on download/preview still works without redoing the work #create did.
+    def ensure_static_site_generated
+      generate unless static_dir.join("index.html").exist?
+    end
+
+    def zip_static_site
+      require "zip"
+
+      zip_path = Rails.root.join("tmp/writebook-static-site.zip")
+      FileUtils.rm_f(zip_path)
+      root = static_dir
+
+      Zip::File.open(zip_path, Zip::File::CREATE) do |zip|
+        Dir.glob(root.join("**", "*").to_s).each do |abs|
+          next if File.directory?(abs)
+          rel = Pathname.new(abs).relative_path_from(root).to_s
+          zip.add("static-site/#{rel}", abs)
+        end
+      end
+
+      zip_path
+    end
+
+    def serve_preview_file
+      rel = params[:path].presence || "index.html"
+      raise ActionController::RoutingError, "not found" if rel.include?("..") || rel.start_with?("/")
+
+      file = static_dir.join(rel)
+      file = file.join("index.html") if file.directory?
+
+      root = static_dir.expand_path.to_s
+      unless file.file? && File.expand_path(file.to_s).start_with?("#{root}/")
+        raise ActionController::RoutingError, "not found"
+      end
+
+      response.headers["Content-Security-Policy"] = nil
+      send_file file.to_s, disposition: "inline"
+    end
 end

--- a/app/controllers/static_exports_controller.rb
+++ b/app/controllers/static_exports_controller.rb
@@ -1,22 +1,34 @@
 class StaticExportsController < ApplicationController
-  # Generating a static copy of the whole library is a site-wide admin action:
-  # it renders every published book and copies every asset and image blob into a
-  # directory on the server. Non-admins get 403; logged-out visitors are sent to
-  # sign in by the default authentication before_action.
+  # Generating a static copy of the library -- the whole thing or a single book
+  # -- is a site-wide admin action: it renders books and copies every asset and
+  # image blob they reference into a directory on the server. Non-admins get 403;
+  # logged-out visitors are sent to sign in by the default authentication
+  # before_action.
   before_action :ensure_can_administer
 
-  # The landing page: explains what the export produces and offers the button
-  # that POSTs to #create to run it.
+  # The landing page: explains what the export produces and offers the form
+  # that POSTs to #create to run it. The form lets the operator pick "all
+  # published books" (optionally with unpublished drafts) or a single book to
+  # export by itself, so @books (every book, published or not) is loaded for the
+  # selector -- a draft can be exported individually even though it isn't
+  # published.
   def show
+    @books = Book.ordered.to_a
   end
 
-  # Renders the published library to tmp/static-site (the same default the
+  # Renders the library to tmp/static-site (the same default the
   # static:generate rake task uses) and redirects to #result, which shows the
-  # result with hosting steps. Pass include_drafts=1 to also export unpublished
-  # books (rolled back so the live database is untouched). Synchronous -- a
-  # published-only export takes seconds; operators with very large libraries
-  # should use the rake task instead (noted on the landing page) to avoid a
-  # request timeout.
+  # result with hosting steps. Two scopes, both rolled back so the live database
+  # is untouched:
+  #
+  #   * Pass book_id=<id> to export a single book by itself, regardless of its
+  #     published state. The library menu in the result shows just that book.
+  #   * Otherwise export every published book. Pass include_drafts=1 to also
+  #     include unpublished books.
+  #
+  # Synchronous -- a published-only export takes seconds; operators with very
+  # large libraries should use the rake task instead (noted on the landing page)
+  # to avoid a request timeout.
   #
   # The redirect (PRG) is required because the landing form is Turbo-driven:
   # a Turbo form submission must receive a 3xx redirect. A 200 HTML response
@@ -24,16 +36,26 @@ class StaticExportsController < ApplicationController
   # redirect to another location". The result is stashed in the session and
   # rendered by the GET #result action, so the URL is also refresh-safe.
   def create
-    include_drafts = params[:include_drafts] == "1"
+    book = Book.find_by(id: params[:book_id].presence)
 
-    # Nothing to render: the library root itself redirects when there are no
-    # published books, so short-circuit before the exporter would hit that.
-    # (With drafts requested, an empty library -- no books at all -- is the same.)
-    if include_drafts ? Book.none? : Book.published.none?
-      session[:static_export_result] = { "empty" => true }
-    else
-      result = generate(include_drafts: include_drafts)
+    if book
+      result = generate(book: book)
+      result.book_id = book.id
+      result.book_title = book.title
       session[:static_export_result] = result.to_h.transform_keys(&:to_s)
+    else
+      include_drafts = params[:include_drafts] == "1"
+      # Nothing to render: the library root itself redirects when there are no
+      # published books, so short-circuit before the exporter would hit that.
+      # (With drafts requested, an empty library -- no books at all -- is the
+      # same. A bogus book_id also lands here, falling back to "nothing to
+      # export" rather than 500ing.)
+      if include_drafts ? Book.none? : Book.published.none?
+        session[:static_export_result] = { "empty" => true }
+      else
+        result = generate(include_drafts: include_drafts)
+        session[:static_export_result] = result.to_h.transform_keys(&:to_s)
+      end
     end
 
     redirect_to static_export_result_url, status: :see_other
@@ -63,9 +85,14 @@ class StaticExportsController < ApplicationController
   # Streams the generated site as a single .zip the operator can download from
   # the browser -- no server shell needed. Reuses the directory #create built;
   # regenerates first if it's absent (e.g. the operator bookmarked this URL).
+  # A book_id query param (carried from the result page's download link when a
+  # single book was exported) names the .zip after the book and scopes a
+  # regeneration to just that book; without it the whole library is exported.
   def download
-    ensure_static_site_generated
-    send_file zip_static_site, filename: "writebook-static-site.zip",
+    book = Book.find_by(id: params[:book_id].presence)
+    ensure_static_site_generated(book: book)
+    filename = book ? "writebook-#{book.slug}.zip" : "writebook-static-site.zip"
+    send_file zip_static_site, filename: filename,
                type: "application/zip", disposition: "attachment"
   end
 
@@ -100,11 +127,17 @@ class StaticExportsController < ApplicationController
     # with its own CurrentAttributes scope instead. The thread is joined so the
     # request still returns the result synchronously.
     #
-    # When include_drafts is set, unpublished books are temporarily published
-    # inside a rolled-back transaction so the exporter renders them and the live
-    # database is left untouched -- the same approach as `bin/rails static:generate
-    # STATIC_ALL=1`.
-    def generate(include_drafts: false)
+    # Two scopes, both inside a rolled-back transaction so the live database is
+    # untouched:
+    #
+    #   * Pass a +book+ to export just that book: it's temporarily made the only
+    #     published book, so the exporter (which reads `Book.published` and the
+    #     library `/` route) renders the library menu and the book by itself,
+    #     regardless of the book's real published state.
+    #   * Otherwise, when +include_drafts+ is set, unpublished books are
+    #     temporarily published so the exporter renders them -- the same
+    #     approach as `bin/rails static:generate STATIC_ALL=1`.
+    def generate(book: nil, include_drafts: false)
       host = request.host
       protocol = request.ssl? ? "https" : "http"
       exporter = -> { Writebook::StaticExporter.new(static_dir, host: host, protocol: protocol).call }
@@ -112,7 +145,14 @@ class StaticExportsController < ApplicationController
       result = nil
       Thread.new do
         Rails.application.executor.wrap do
-          if include_drafts
+          if book
+            Book.transaction do
+              Book.where.not(id: book.id).update_all(published: false)
+              book.update_columns(published: true)
+              result = exporter.call
+              raise ActiveRecord::Rollback
+            end
+          elsif include_drafts
             Book.transaction do
               Book.where(published: [false, nil]).update_all(published: true)
               result = exporter.call
@@ -127,9 +167,11 @@ class StaticExportsController < ApplicationController
     end
 
     # Build the static site only when it isn't already on disk, so a direct hit
-    # on download/preview still works without redoing the work #create did.
-    def ensure_static_site_generated
-      generate unless static_dir.join("index.html").exist?
+    # on download/preview still works without redoing the work #create did. When
+    # a +book+ is given (a bookmarked single-book download URL), a regeneration
+    # is scoped to just that book instead of the whole library.
+    def ensure_static_site_generated(book: nil)
+      generate(book: book) unless static_dir.join("index.html").exist?
     end
 
     def zip_static_site

--- a/app/controllers/static_exports_controller.rb
+++ b/app/controllers/static_exports_controller.rb
@@ -11,22 +11,51 @@ class StaticExportsController < ApplicationController
   end
 
   # Renders the published library to tmp/static-site (the same default the
-  # static:generate rake task uses) and shows the result with hosting steps.
-  # Pass include_drafts=1 to also export unpublished books (rolled back so the
-  # live database is untouched). Synchronous -- a published-only export takes
-  # seconds; operators with very large libraries should use the rake task
-  # instead (noted on the landing page) to avoid a request timeout.
+  # static:generate rake task uses) and redirects to #result, which shows the
+  # result with hosting steps. Pass include_drafts=1 to also export unpublished
+  # books (rolled back so the live database is untouched). Synchronous -- a
+  # published-only export takes seconds; operators with very large libraries
+  # should use the rake task instead (noted on the landing page) to avoid a
+  # request timeout.
+  #
+  # The redirect (PRG) is required because the landing form is Turbo-driven:
+  # a Turbo form submission must receive a 3xx redirect. A 200 HTML response
+  # (the former `render :create`) makes Turbo throw "Form responses must
+  # redirect to another location". The result is stashed in the session and
+  # rendered by the GET #result action, so the URL is also refresh-safe.
   def create
-    @output_dir = static_dir.expand_path
     include_drafts = params[:include_drafts] == "1"
 
     # Nothing to render: the library root itself redirects when there are no
     # published books, so short-circuit before the exporter would hit that.
     # (With drafts requested, an empty library -- no books at all -- is the same.)
     if include_drafts ? Book.none? : Book.published.none?
+      session[:static_export_result] = { "empty" => true }
+    else
+      result = generate(include_drafts: include_drafts)
+      session[:static_export_result] = result.to_h.transform_keys(&:to_s)
+    end
+
+    redirect_to static_export_result_url, status: :see_other
+  end
+
+  # GET: renders the result page stashed by #create. Refresh-safe -- the URL
+  # stays valid until another export overwrites the session slot. A direct hit
+  # with no stashed result (e.g. the session expired) falls back to the
+  # landing page so the operator is never left on a dead URL.
+  def result
+    data = session[:static_export_result]
+    if data.blank?
+      redirect_to static_export_url, status: :see_other
+      return
+    end
+
+    session.delete(:static_export_result)
+    @output_dir = static_dir.expand_path
+    if data["empty"]
       render :empty
     else
-      @result = generate(include_drafts: include_drafts)
+      @result = Writebook::StaticExporter::Result.new(**data.symbolize_keys)
       render :create
     end
   end

--- a/app/controllers/static_exports_controller.rb
+++ b/app/controllers/static_exports_controller.rb
@@ -1,0 +1,29 @@
+class StaticExportsController < ApplicationController
+  # Generating a static copy of the whole library is a site-wide admin action:
+  # it renders every published book and copies every asset and image blob into a
+  # directory on the server. Non-admins get 403; logged-out visitors are sent to
+  # sign in by the default authentication before_action.
+  before_action :ensure_can_administer
+
+  # The landing page: explains what the export produces and offers the button
+  # that POSTs to #create to run it.
+  def show
+  end
+
+  # Renders the published library to tmp/static-site (the same default the
+  # static:generate rake task uses) and shows the result with hosting steps.
+  # Synchronous -- Writebook runs no background jobs, and a published-only
+  # export takes seconds. Operators with very large libraries should use the
+  # rake task instead (noted on the result page) to avoid a request timeout.
+  def create
+    dir = Rails.root.join("tmp/static-site")
+    @result = Writebook::StaticExporter.new(
+      dir,
+      host: request.host,
+      protocol: request.ssl? ? "https" : "http"
+    ).call
+    @output_dir = dir
+
+    render :create
+  end
+end

--- a/app/javascript/controllers/static_search_controller.js
+++ b/app/javascript/controllers/static_search_controller.js
@@ -1,0 +1,181 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Client-side search for the Writebook static export. Replaces the server's
+// POST /books/:id/search (SQLite FTS5 over leaf_search_index) with an in-memory
+// search over a per-book _search.json index built at export time (see
+// Writebook::StaticExporter#build_search_index).
+//
+// The exporter attaches this controller to the existing <form id="search_form">
+// inside the search dialog and sets data-static-search-index-path to the
+// relative path to the book's _search.json. The search input (#search, which
+// lives outside the form and references it via form="search_form") and the
+// <turbo-frame id="search"> that holds the form are queried by id, since they
+// are not descendants of the controller element.
+//
+// Results render into a .search__results div appended after the form inside the
+// <turbo-frame id="search">, mirroring the server's _results/_result markup
+// (title with <mark>, ~20-token content snippet with <mark>, a reading-mode
+// link carrying ?search= so the destination page highlights matches, "No
+// matches." empty state, 50-result cap, title hits weighted 2x like the
+// server's bm25(leaf_search_index, 2.0)).
+//
+// This controller is eager-loaded in the live app too (via the importmap's
+// pin_all_from "app/javascript/controllers"), but it only activates where
+// data-controller="static-search" is present, which the exporter injects only
+// into exported pages -- so the live app's server-side search is untouched.
+export default class extends Controller {
+  connect() {
+    this.entries = null       // Array of { id, slug, title, url, content }
+    this.titleIndex = null    // Map<term, Set<entryIndex>>
+    this.contentIndex = null  // Map<term, Set<entryIndex>>
+    this._loading = null
+    this._timer = null
+    this.element.addEventListener("submit", this.handleSubmit)
+    const input = this.input
+    if (input) input.addEventListener("input", this.handleInput)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("submit", this.handleSubmit)
+    const input = this.input
+    if (input) input.removeEventListener("input", this.handleInput)
+    clearTimeout(this._timer)
+  }
+
+  get input()  { return document.getElementById("search") }
+  get frame() { return document.querySelector('turbo-frame[id="search"]') }
+  get indexPath() { return this.element.dataset.staticSearchIndexPath }
+
+  // Fetch and build the index on first interaction. Resolves to the entries
+  // array, or null if the index could not be loaded. Concurrent callers share
+  // one in-flight promise. The URL is the controller's relative index path
+  // resolved against location.pathname with a trailing slash, mirroring the
+  // sidebar fetch so it works at a domain root and under any subpath.
+  ensureIndex() {
+    if (this.entries) return Promise.resolve(this.entries)
+    if (this._loading) return this._loading
+    let p = location.pathname
+    if (!p.endsWith("/")) p += "/"
+    this._loading = fetch(p + this.indexPath)
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => { if (data) { this.entries = data; this.buildIndex() } return data })
+      .catch(() => null)
+    return this._loading
+  }
+
+  buildIndex() {
+    this.titleIndex = new Map()
+    this.contentIndex = new Map()
+    const add = (map, term, i) => {
+      let set = map.get(term); if (!set) { set = new Set(); map.set(term, set) }
+      set.add(i)
+    }
+    this.entries.forEach((entry, i) => {
+      this.tokenize(entry.title).forEach((t) => add(this.titleIndex, t, i))
+      this.tokenize(entry.content).forEach((t) => add(this.contentIndex, t, i))
+    })
+  }
+
+  tokenize(text) { return (text || "").toLowerCase().split(/[^0-9a-z]+/).filter(Boolean) }
+  queryTerms(q)  { return (q || "").toLowerCase().split(/[^0-9a-z]+/).filter(Boolean) }
+
+  handleSubmit = (event) => { event.preventDefault(); this.run(this.input ? this.input.value : "") }
+
+  handleInput = (event) => {
+    clearTimeout(this._timer)
+    this._timer = setTimeout(() => this.run(event.target.value), 120)
+  }
+
+  async run(query) {
+    const data = await this.ensureIndex()
+    if (!data) { this.render([]); return }
+    const terms = this.queryTerms(query)
+    if (!terms.length) { this.render([]); return }
+    const scores = new Map()
+    terms.forEach((term) => {
+      ;(this.titleIndex.get(term) || []).forEach((i) => scores.set(i, (scores.get(i) || 0) + 2))
+      ;(this.contentIndex.get(term) || []).forEach((i) => scores.set(i, (scores.get(i) || 0) + 1))
+    })
+    const hits = []
+    scores.forEach((score, i) => hits.push({ entry: data[i], score }))
+    hits.sort((a, b) => b.score - a.score)
+    this.render(hits.slice(0, 50), terms)
+  }
+
+  render(hits, terms) {
+    const frame = this.frame
+    if (!frame) return
+    let results = frame.querySelector(":scope > .search__results")
+    if (!results) {
+      results = document.createElement("div")
+      results.className = "search__results flex flex-column margin-block-start"
+      frame.appendChild(results)
+    }
+    if (!hits || !hits.length) {
+      results.innerHTML = '<p class="search__no_matches txt-align-center">No matches.</p>'
+      return
+    }
+    const q = (this.input && this.input.value) || ""
+    results.innerHTML = hits.map(({ entry }) => {
+      const href = entry.url + "?search=" + encodeURIComponent(q)
+      const title = this.highlight(entry.title, terms)
+      const snippet = this.snippet(entry.content, terms)
+      return `<a class="search__result hide_from_edit_mode txt-ink" data-turbo-frame="_top" href="${this.escapeAttr(href)}"><strong>${title}:</strong> ${snippet}</a>`
+    }).join("")
+  }
+
+  // Wrap whole-word matches of any term in <mark>. The text is HTML-escaped first,
+  // so only the literal <mark> tags we insert become live markup. Longest terms
+  // first so a longer term wins before a shorter one nested inside it. Mirrors
+  // SearchesHelper#whole_word_matchers (/\bterm\b/).
+  highlight(text, terms) {
+    const escaped = this.escapeHtml(text || "")
+    const sorted = [...(terms || [])].sort((a, b) => b.length - a.length)
+    let out = escaped
+    sorted.forEach((term) => {
+      const e = this.escapeHtml(term).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      out = out.replace(new RegExp("\\b" + e + "\\b", "gi"), (m) => "<mark>" + m + "</mark>")
+    })
+    return out
+  }
+
+  // A ~20-token window (10 words either side of the first whole-word match),
+  // elided with "..." when truncated, matches wrapped in <mark> -- mirroring
+  // FTS5 snippet(…, '...', 20). Title-only hits fall back to a leading window.
+  snippet(content, terms) {
+    const text = (content || "").replace(/\s+/g, " ").trim()
+    if (!text) return ""
+    const low = text.toLowerCase()
+    const sorted = [...(terms || [])].sort((a, b) => b.length - a.length)
+    let at = -1, term = ""
+    for (const t of sorted) {
+      const m = new RegExp("\\b" + t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\b").exec(low)
+      if (m) { at = m.index; term = t; break }
+    }
+    if (at === -1) {
+      const head = text.split(" ").slice(0, 20).join(" ")
+      return this.escapeHtml(head) + (text.length > head.length ? " ..." : "")
+    }
+    const before = text.slice(0, at)
+    const match = text.slice(at, at + term.length)
+    const after = text.slice(at + term.length)
+    const W = 10
+    const bWords = before.split(" ").filter(Boolean)
+    const aWords = after.split(" ").filter(Boolean)
+    const keepB = bWords.slice(Math.max(0, bWords.length - W))
+    const keepA = aWords.slice(0, W)
+    const lead = bWords.length > W ? "... " : ""
+    const trail = aWords.length > W ? " ..." : ""
+    const parts = []
+    if (keepB.length) parts.push(this.highlight(keepB.join(" "), sorted))
+    parts.push("<mark>" + this.escapeHtml(match) + "</mark>")
+    if (keepA.length) parts.push(this.highlight(keepA.join(" "), sorted))
+    return lead + parts.join(" ") + trail
+  }
+
+  escapeHtml(s) {
+    return (s || "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]))
+  }
+
+  escapeAttr(s) { return (s || "").replace(/"/g, "&quot;") }
+}

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -11,6 +11,13 @@
     </a>
 
     <% if Current.user %>
+      <% if Current.user.can_administer? %>
+        <%= link_to static_export_path, class: "btn" do %>
+          <%= image_tag "download.svg", aria: { hidden: true }, size: 24 %>
+          <span class="for-screen-reader">Export to static site</span>
+        <% end %>
+      <% end %>
+
       <%= link_to users_path, class: "btn" do %>
         <%= image_tag "settings.svg", aria: { hidden: true }, size: 24 %>
         <span class="for-screen-reader">Manage people and settings</span>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -59,7 +59,7 @@
       <% else %>
         <span class="book__cover-wrapper">
           <%= image_tag "empty-cover.png", alt: "Book cover", class: "book__cover margin-block-none center" %>
-          <span class="book__title overflow-line-clamp pad txt-align-start txt-tight-lines"" style="--lines: 6" aria-hidden="true"><%= @book.title %></span>
+          <span class="book__title overflow-line-clamp pad txt-align-start txt-tight-lines" style="--lines: 6" aria-hidden="true"><%= @book.title %></span>
         </span>
       <% end %>
 

--- a/app/views/static_exports/create.html.erb
+++ b/app/views/static_exports/create.html.erb
@@ -1,0 +1,82 @@
+<% content_for(:title) { "Static site ready" } %>
+
+<% content_for :header do %>
+  <nav>
+    <%= link_to root_path, class: "btn" do %>
+      <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
+      <span class="for-screen-reader">Go back</span>
+    <% end %>
+
+    <div class="breadcrumbs">
+      <%= render "books/index_link" %>
+      <span class="flex-item-no-shrink">▸</span>
+      <%= link_to "Export to static site", static_export_path %>
+      <span class="flex-item-no-shrink">▸</span>
+      <strong>Result</strong>
+    </div>
+  </nav>
+<% end %>
+
+<div class="panel borderless center pad fill-shade flex flex-column margin-block gap">
+  <h1 class="txt-large--responsive">Your static site is ready</h1>
+
+  <p class="txt-medium--responsive">
+    Rendered <strong><%= pluralize(@result.books, "book") %></strong>,
+    <strong><%= pluralize(@result.leaves, "page") %></strong>,
+    <%= pluralize(@result.assets, "asset file") %>, and
+    <%= pluralize(@result.resources, "image") %>
+    (<strong><%= @result.bytes %></strong>).
+    <% if @result.resource_failures.to_i.positive? %>
+      <strong><%= @result.resource_failures %> image(s) could not be copied — see the server log.</strong>
+    <% end %>
+  </p>
+
+  <%= button_to static_export_path, method: :post, class: "btn btn--reversed center txt-medium" do %>
+    <%= image_tag "refresh.svg", aria: { hidden: true }, size: 24 %>
+    <span>Generate again</span>
+  <% end %>
+</div>
+
+<div class="panel borderless center pad fill-none flex flex-column gap txt-medium--responsive">
+  <div>
+    <h2 class="txt-medium margin-block-end-half">Where it is</h2>
+    <p class="margin-block-none txt-subtle">
+      On this server: <code><%= @output_dir %></code>
+    </p>
+  </div>
+
+  <div>
+    <h2 class="txt-medium margin-block-end-half">Preview locally</h2>
+    <pre class="margin-block-none"><code>cd <%= @output_dir %>
+python3 -m http.server 8080</code></pre>
+    <p class="margin-block-none txt-subtle">Then open <code>http://localhost:8080</code>.</p>
+  </div>
+
+  <div>
+    <h2 class="txt-medium margin-block-end-half">Deploy it</h2>
+    <p class="margin-block-none">
+      Copy the <em>contents</em> of that directory to any static host — Netlify,
+      Cloudflare Pages, GitHub Pages, an S3 bucket, or your own nginx. URLs are
+      root-relative, so the site works at any domain's root with no extra config.
+    </p>
+  </div>
+
+  <div>
+    <h2 class="txt-medium margin-block-end-half">Including drafts, or very large libraries</h2>
+    <p class="margin-block-none txt-subtle">
+      Only published books are exported here. To include unpublished drafts, or to
+      export without holding a web request open, run
+      <code>bin/rails static:generate STATIC_ALL=1</code> from the server shell —
+      it leaves your live database untouched.
+    </p>
+  </div>
+</div>
+
+<% content_for :footer do %>
+  <nav class="flex align-center justify-center gap">
+    <%= link_to root_path, class: "btn" do %>
+      <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
+      <span>Back to library</span>
+    <% end %>
+  </nav>
+<% end %>

--- a/app/views/static_exports/create.html.erb
+++ b/app/views/static_exports/create.html.erb
@@ -26,15 +26,26 @@
     <%= pluralize(@result.assets, "asset file") %>, and
     <%= pluralize(@result.resources, "image") %>
     (<strong><%= @result.bytes %></strong>).
-    <% if @result.resource_failures.to_i.positive? %>
-      <strong><%= @result.resource_failures %> image(s) could not be copied — see the server log.</strong>
-    <% end %>
   </p>
 
-  <%= button_to static_export_path, method: :post, class: "btn btn--reversed center txt-medium" do %>
-    <%= image_tag "refresh.svg", aria: { hidden: true }, size: 24 %>
-    <span>Generate again</span>
+  <% if @result.resource_failures.to_i.positive? %>
+    <p class="txt-medium--responsive">
+      <strong><%= pluralize(@result.resource_failures, "image") %> couldn't be copied.</strong>
+      The site is still usable, but those images will be missing where they're
+      referenced. Details are in the server log.
+    </p>
   <% end %>
+
+  <div class="flex align-center justify-center gap">
+    <%= link_to static_export_download_path, class: "btn btn--reversed txt-medium", data: { turbo: false } do %>
+      <%= image_tag "download.svg", aria: { hidden: true }, size: 24 %>
+      <span>Download .zip</span>
+    <% end %>
+    <%= link_to static_site_preview_path, class: "btn txt-medium", target: "_blank" do %>
+      <%= image_tag "eye.svg", aria: { hidden: true }, size: 24 %>
+      <span>Preview site</span>
+    <% end %>
+  </div>
 </div>
 
 <div class="panel borderless center pad fill-none flex flex-column gap txt-medium--responsive">
@@ -77,6 +88,10 @@ python3 -m http.server 8080</code></pre>
     <%= link_to root_path, class: "btn" do %>
       <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
       <span>Back to library</span>
+    <% end %>
+    <%= button_to static_export_path, method: :post, class: "btn" do %>
+      <%= image_tag "refresh.svg", aria: { hidden: true }, size: 24 %>
+      <span>Generate again</span>
     <% end %>
   </nav>
 <% end %>

--- a/app/views/static_exports/create.html.erb
+++ b/app/views/static_exports/create.html.erb
@@ -21,11 +21,19 @@
   <h1 class="txt-large--responsive">Your static site is ready</h1>
 
   <p class="txt-medium--responsive">
-    Rendered <strong><%= pluralize(@result.books, "book") %></strong>,
-    <strong><%= pluralize(@result.leaves, "page") %></strong>,
-    <%= pluralize(@result.assets, "asset file") %>, and
-    <%= pluralize(@result.resources, "image") %>
-    (<strong><%= @result.bytes %></strong>).
+    <% if @result.book_title.present? %>
+      Rendered <strong><%= @result.book_title %></strong> —
+      <strong><%= pluralize(@result.leaves, "page") %></strong>,
+      <%= pluralize(@result.assets, "asset file") %>, and
+      <%= pluralize(@result.resources, "image") %>
+      (<strong><%= @result.bytes %></strong>).
+    <% else %>
+      Rendered <strong><%= pluralize(@result.books, "book") %></strong>,
+      <strong><%= pluralize(@result.leaves, "page") %></strong>,
+      <%= pluralize(@result.assets, "asset file") %>, and
+      <%= pluralize(@result.resources, "image") %>
+      (<strong><%= @result.bytes %></strong>).
+    <% end %>
   </p>
 
   <% if @result.resource_failures.to_i.positive? %>
@@ -37,7 +45,7 @@
   <% end %>
 
   <div class="flex align-center justify-center gap">
-    <%= link_to static_export_download_path, class: "btn btn--reversed txt-medium", data: { turbo: false } do %>
+    <%= link_to static_export_download_path(book_id: @result.book_id), class: "btn btn--reversed txt-medium", data: { turbo: false } do %>
       <%= image_tag "download.svg", aria: { hidden: true }, size: 24 %>
       <span>Download .zip</span>
     <% end %>
@@ -89,7 +97,7 @@ python3 -m http.server 8080</code></pre>
       <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
       <span>Back to library</span>
     <% end %>
-    <%= button_to static_export_path, method: :post, class: "btn", data: { turbo_submits_with: "Generating…" } do %>
+    <%= button_to static_export_path, method: :post, params: { book_id: @result.book_id }, class: "btn", data: { turbo_submits_with: "Generating…" } do %>
       <%= image_tag "refresh.svg", aria: { hidden: true }, size: 24 %>
       <span>Generate again</span>
     <% end %>

--- a/app/views/static_exports/create.html.erb
+++ b/app/views/static_exports/create.html.erb
@@ -89,7 +89,7 @@ python3 -m http.server 8080</code></pre>
       <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
       <span>Back to library</span>
     <% end %>
-    <%= button_to static_export_path, method: :post, class: "btn" do %>
+    <%= button_to static_export_path, method: :post, class: "btn", data: { turbo_submits_with: "Generating…" } do %>
       <%= image_tag "refresh.svg", aria: { hidden: true }, size: 24 %>
       <span>Generate again</span>
     <% end %>

--- a/app/views/static_exports/empty.html.erb
+++ b/app/views/static_exports/empty.html.erb
@@ -33,9 +33,8 @@
 
 <div class="panel borderless center pad fill-none flex flex-column gap txt-subtle txt-medium--responsive">
   <p class="margin-block-none">
-    To include unpublished drafts as well, run
-    <code>bin/rails static:generate STATIC_ALL=1</code> from the server shell — it
-    leaves your live database untouched.
+    Or go back and check <strong>“Include unpublished drafts”</strong> to export your
+    drafts too — your live database is left untouched.
   </p>
 </div>
 

--- a/app/views/static_exports/empty.html.erb
+++ b/app/views/static_exports/empty.html.erb
@@ -1,0 +1,49 @@
+<% content_for(:title) { "Nothing to export" } %>
+
+<% content_for :header do %>
+  <nav>
+    <%= link_to root_path, class: "btn" do %>
+      <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
+      <span class="for-screen-reader">Go back</span>
+    <% end %>
+
+    <div class="breadcrumbs">
+      <%= render "books/index_link" %>
+      <span class="flex-item-no-shrink">▸</span>
+      <%= link_to "Export to static site", static_export_path %>
+      <span class="flex-item-no-shrink">▸</span>
+      <strong>Result</strong>
+    </div>
+  </nav>
+<% end %>
+
+<div class="panel borderless center pad fill-shade flex flex-column margin-block gap">
+  <h1 class="txt-large--responsive">Nothing to export yet</h1>
+
+  <p class="txt-medium--responsive">
+    You don't have any published books, so there's nothing to render. Publish a
+    book from its settings, then generate the static site again.
+  </p>
+
+  <%= button_to static_export_path, method: :post, class: "btn btn--reversed center txt-medium" do %>
+    <%= image_tag "refresh.svg", aria: { hidden: true }, size: 24 %>
+    <span>Generate again</span>
+  <% end %>
+</div>
+
+<div class="panel borderless center pad fill-none flex flex-column gap txt-subtle txt-medium--responsive">
+  <p class="margin-block-none">
+    To include unpublished drafts as well, run
+    <code>bin/rails static:generate STATIC_ALL=1</code> from the server shell — it
+    leaves your live database untouched.
+  </p>
+</div>
+
+<% content_for :footer do %>
+  <nav class="flex align-center justify-center gap">
+    <%= link_to root_path, class: "btn" do %>
+      <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
+      <span>Back to library</span>
+    <% end %>
+  </nav>
+<% end %>

--- a/app/views/static_exports/show.html.erb
+++ b/app/views/static_exports/show.html.erb
@@ -1,0 +1,45 @@
+<% content_for(:title) { "Export to static site" } %>
+
+<% content_for :header do %>
+  <nav>
+    <%= link_to root_path, class: "btn" do %>
+      <%= image_tag "arrow-left.svg", aria: { hidden: true }, size: 24 %>
+      <span class="for-screen-reader">Go back</span>
+    <% end %>
+
+    <div class="breadcrumbs">
+      <%= render "books/index_link" %>
+      <span class="flex-item-no-shrink">▸</span>
+      <strong>Export to static site</strong>
+    </div>
+  </nav>
+<% end %>
+
+<div class="panel borderless center pad fill-shade flex flex-column margin-block gap">
+  <h1 class="txt-large--responsive">Export to a static site</h1>
+
+  <p class="txt-medium--responsive">
+    Generate a self-contained HTML version of your published library — the menu of
+    books, every book's table of contents, and every page — with all CSS, JavaScript,
+    and image files copied in. No Rails process, login, or editing machinery: the
+    result can be hosted anywhere.
+  </p>
+
+  <%= button_to static_export_path, method: :post, class: "btn btn--reversed center txt-medium" do %>
+    <%= image_tag "download.svg", aria: { hidden: true }, size: 24 %>
+    <span>Generate static site</span>
+  <% end %>
+</div>
+
+<div class="panel borderless center pad fill-none flex flex-column gap txt-subtle txt-medium--responsive">
+  <p class="margin-block-none">Only <strong>published</strong> books are included.</p>
+  <p class="margin-block-none">
+    To include unpublished drafts as well, run
+    <code>bin/rails static:generate STATIC_ALL=1</code> from the server shell — it
+    leaves your live database untouched.
+  </p>
+  <p class="margin-block-none">
+    For very large libraries, prefer that rake task too: it avoids holding a single
+    web request open while the whole library renders.
+  </p>
+</div>

--- a/app/views/static_exports/show.html.erb
+++ b/app/views/static_exports/show.html.erb
@@ -26,6 +26,12 @@
   </p>
 
   <%= form_with url: static_export_path, method: :post, class: "flex flex-column align-center gap" do %>
+    <label class="flex flex-column align-center gap txt-medium--responsive">
+      <span>Which book to export</span>
+      <%= select_tag :book_id,
+            options_for_select([["All published books", ""]] + @books.map { |book| [book.title, book.id] }) %>
+    </label>
+
     <label class="flex align-center gap txt-medium--responsive">
       <%= check_box_tag :include_drafts, "1", false %>
       Include unpublished drafts
@@ -39,9 +45,12 @@
 
 <div class="panel borderless center pad fill-none flex flex-column gap txt-subtle txt-medium--responsive">
   <p class="margin-block-none">
-    By default only <strong>published</strong> books are included. Check the box
-    above to include unpublished drafts too — your live database is left untouched
-    (the change is rolled back the moment the export finishes).
+    Pick <strong>All published books</strong> to export the whole library, or pick a
+    single book to export just that one — handy for sharing or hosting one title at a
+    time. A single book is exported whether or not it's published; the
+    <strong>Include unpublished drafts</strong> box only applies when exporting all
+    books. Your live database is left untouched either way (the change is rolled back
+    the moment the export finishes).
   </p>
   <p class="margin-block-none">
     For a very large library, generating from the browser may time out; in that case

--- a/app/views/static_exports/show.html.erb
+++ b/app/views/static_exports/show.html.erb
@@ -19,27 +19,33 @@
   <h1 class="txt-large--responsive">Export to a static site</h1>
 
   <p class="txt-medium--responsive">
-    Generate a self-contained HTML version of your published library — the menu of
-    books, every book's table of contents, and every page — with all CSS, JavaScript,
-    and image files copied in. No Rails process, login, or editing machinery: the
-    result can be hosted anywhere.
+    Generate a self-contained HTML version of your library — the menu of books,
+    every book's table of contents, and every page — with all CSS, JavaScript, and
+    image files copied in. No Rails process, login, or editing machinery: the result
+    can be hosted anywhere.
   </p>
 
-  <%= button_to static_export_path, method: :post, class: "btn btn--reversed center txt-medium" do %>
-    <%= image_tag "download.svg", aria: { hidden: true }, size: 24 %>
-    <span>Generate static site</span>
+  <%= form_with url: static_export_path, method: :post, class: "flex flex-column align-center gap" do %>
+    <label class="flex align-center gap txt-medium--responsive">
+      <%= check_box_tag :include_drafts, "1", false %>
+      Include unpublished drafts
+    </label>
+    <%= button_tag type: :submit, class: "btn btn--reversed center txt-medium", data: { turbo_submits_with: "Generating…" } do %>
+      <%= image_tag "download.svg", aria: { hidden: true }, size: 24 %>
+      <span>Generate static site</span>
+    <% end %>
   <% end %>
 </div>
 
 <div class="panel borderless center pad fill-none flex flex-column gap txt-subtle txt-medium--responsive">
-  <p class="margin-block-none">Only <strong>published</strong> books are included.</p>
   <p class="margin-block-none">
-    To include unpublished drafts as well, run
-    <code>bin/rails static:generate STATIC_ALL=1</code> from the server shell — it
-    leaves your live database untouched.
+    By default only <strong>published</strong> books are included. Check the box
+    above to include unpublished drafts too — your live database is left untouched
+    (the change is rolled back the moment the export finishes).
   </p>
   <p class="margin-block-none">
-    For very large libraries, prefer that rake task too: it avoids holding a single
-    web request open while the whole library renders.
+    For a very large library, generating from the browser may time out; in that case
+    run <code>bin/rails static:generate</code> (or <code>STATIC_ALL=1</code>) from the
+    server shell.
   </p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,11 @@ Rails.application.routes.draw do
     end
   end
 
+  # Generate a self-contained static HTML version of the published library.
+  # Admin-only (see StaticExportsController); the result page tells the
+  # operator where the files are and how to host them.
+  resource :static_export, only: %i[ show create ], controller: "static_exports"
+
   resources :books, except: %i[ index show ] do
     resource :publication, controller: "books/publications", only: %i[ show edit update ]
     resource :bookmark, controller: "books/bookmarks", only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   # generated site as a .zip; #preview serves it from inside the app under
   # /static-site/ so the operator can see it in a browser tab.
   resource :static_export, only: %i[ show create ], controller: "static_exports"
+  get "/static_export/result", to: "static_exports#result", as: :static_export_result
   get "/static_export/download", to: "static_exports#download", as: :static_export_download
   get "/static-site/(*path)", to: "static_exports#preview", as: :static_site_preview, defaults: { path: "index.html" }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,12 @@ Rails.application.routes.draw do
 
   # Generate a self-contained static HTML version of the published library.
   # Admin-only (see StaticExportsController); the result page tells the
-  # operator where the files are and how to host them.
+  # operator where the files are and how to host them. #download streams the
+  # generated site as a .zip; #preview serves it from inside the app under
+  # /static-site/ so the operator can see it in a browser tab.
   resource :static_export, only: %i[ show create ], controller: "static_exports"
+  get "/static_export/download", to: "static_exports#download", as: :static_export_download
+  get "/static-site/(*path)", to: "static_exports#preview", as: :static_site_preview, defaults: { path: "index.html" }
 
   resources :books, except: %i[ index show ] do
     resource :publication, controller: "books/publications", only: %i[ show edit update ]

--- a/lib/tasks/static.rake
+++ b/lib/tasks/static.rake
@@ -1,0 +1,20 @@
+desc "Generate a static HTML site from published books into DIR (default: tmp/static-site). " \
+     "Set STATIC_HOST for absolute URLs; STATIC_ALL=1 to include unpublished books."
+namespace :static do
+  task :generate, [:dir] => :environment do |_task, args|
+    dir = args[:dir] || "tmp/static-site"
+    host = ENV.fetch("STATIC_HOST", "example.com")
+
+    if ENV["STATIC_ALL"] == "1"
+      # Temporarily publish every book so the exporter renders it, then roll the
+      # change back so the live database is left untouched.
+      Book.transaction do
+        Book.where(published: [false, nil]).update_all(published: true)
+        Writebook::StaticExporter.new(dir, host: host, verbose: true).call
+        raise ActiveRecord::Rollback
+      end
+    else
+      Writebook::StaticExporter.new(dir, host: host, verbose: true).call
+    end
+  end
+end

--- a/lib/writebook/static_exporter.rb
+++ b/lib/writebook/static_exporter.rb
@@ -53,27 +53,44 @@ module Writebook
     SIDEBAR_ASIDE_PATTERN = /<aside\s[^>]*?id="sidebar"[^>]*>.*?<\/aside>/m
 
     # The inline script that swaps the placeholder <aside> for the shared
-    # sidebar fragment. The fetch URL is root-relative (/<book_rel>/_sidebar.html)
-    # so it resolves against the host root regardless of the leaf's URL —
-    # critically, whether or not the browser's URL carries a trailing slash.
-    # A relative "../../_sidebar.html" depends on document.baseURI, which is
-    # the no-slash URL when Turbo navigates to a leaf via a slash-less nav link,
-    # and then resolves one level too shallow and 404s. The !r.ok guard stops a
-    # 404 response body from being read as text and outerHTML'd into the page
-    # (fetch does not reject on 404; the .catch only covers network errors).
+    # sidebar fragment. The fetch target is RELATIVE -- "../../_sidebar.html",
+    # resolved against the leaf's own directory -- so the same export works
+    # whether it is hosted at the domain root (a downloaded .zip uploaded
+    # straight to a static host) or under a subpath (the in-app /static-site
+    # preview, a GitHub Pages project site, any /repo/ prefix). A root-relative
+    # "/<book_rel>/_sidebar.html" would 404 under every subpath; a bare relative
+    # path depends on document.baseURI and 404s one level too shallow when the
+    # leaf URL has no trailing slash (the common case -- Turbo serves leaf links
+    # without one).
+    #
+    # The trailing-slash normalization is the crux. Forcing the pathname to end
+    # in "/" promotes the final segment from a "file" to a directory, so "../../"
+    # then climbs exactly two levels: from <leaf_slug>/ up past <leaf_id>/ to
+    # <book_rel>/, where _sidebar.html lives. The built string starts with "/",
+    # so fetch resolves it against the origin -- NOT document.baseURI -- which
+    # removes the last baseURI dependence and makes the resolution deterministic
+    # across slash/no-slash and root/subpath alike.
+    #
+    # The !r.ok guard stops a 404 response body from being read as text and
+    # outerHTML'd into the page (fetch does not reject on 404; the .catch only
+    # covers network errors).
     SIDEBAR_PLACEHOLDER = '<aside id="sidebar" aria-label="Table of Contents" data-static-sidebar-placeholder></aside>'
 
-    def sidebar_fetch_script(book_rel)
+    def sidebar_fetch_script
       <<~JS
         <script>
-        fetch("/#{book_rel}/_sidebar.html").then(function(r){
+        (function(){
+        var p=location.pathname;
+        if(!p.endsWith("/"))p+="/";
+        fetch(p+"../../_sidebar.html").then(function(r){
         if(!r.ok)return null;
         return r.text();
         }).then(function(h){
         if(!h)return;
-        var p=document.querySelector("aside[data-static-sidebar-placeholder]");
-        if(p)p.outerHTML=h;
+        var s=document.querySelector("aside[data-static-sidebar-placeholder]");
+        if(s)s.outerHTML=h;
         }).catch(function(){});
+        })();
         </script>
       JS
     end
@@ -262,7 +279,7 @@ module Writebook
         write("#{book_rel}/_sidebar.html", sidebar)
         log "  externalized sidebar -> #{book_rel}/_sidebar.html (#{sidebar.bytesize} bytes)"
 
-        replacement = SIDEBAR_PLACEHOLDER + "\n" + sidebar_fetch_script(book_rel)
+        replacement = SIDEBAR_PLACEHOLDER + "\n" + sidebar_fetch_script
         rendered_index = @rendered.to_h { |rel, html| [rel, html] }
 
         leaf_htmls.each do |rel, html|

--- a/lib/writebook/static_exporter.rb
+++ b/lib/writebook/static_exporter.rb
@@ -37,6 +37,14 @@ module Writebook
     # logged-out read views.
     AUTH_LINK_PATTERN = /<a\s[^>]*href="(?:\/(?:session|users|account)|[^"]*\/edit)[^"]*"[^>]*>.*?<\/a>/m
 
+    # The search dialog's <form id="search_form"> posts to /books/:id/search,
+    # a route that exists only in the live app. On a static host it 404s into
+    # Turbo's "content missing" fallback. Neutralize the form in the export:
+    # drop its action and short-circuit submission (data-turbo="false" makes
+    # Turbo ignore the form; onsubmit="return false" cancels the native submit),
+    # so the dialog still opens for visual parity but no request ever fires.
+    SEARCH_FORM_PATTERN = /<form\s[^>]*\bid="search_form"[^>]*>/.freeze
+
     # The table-of-contents sidebar embedded in every leaf page. It is
     # byte-identical across every leaf of a book, so it is externalized once
     # per book and loaded with a small inline fetch (see +externalize_sidebar+).
@@ -45,18 +53,30 @@ module Writebook
     SIDEBAR_ASIDE_PATTERN = /<aside\s[^>]*?id="sidebar"[^>]*>.*?<\/aside>/m
 
     # The inline script that swaps the placeholder <aside> for the shared
-    # sidebar fragment. Two levels up from a leaf's
-    # <book_rel>/<leaf_id>/<leaf_slug>/index.html lands on <book_rel>/.
-    SIDEBAR_FETCH_SCRIPT = <<~JS.freeze
-      <script>
-      fetch("../../_sidebar.html").then(r=>r.text()).then(function(h){
-      var p=document.querySelector("aside[data-static-sidebar-placeholder]");
-      if(p) p.outerHTML=h;
-      }).catch(function(){});
-      </script>
-    JS
-
+    # sidebar fragment. The fetch URL is root-relative (/<book_rel>/_sidebar.html)
+    # so it resolves against the host root regardless of the leaf's URL —
+    # critically, whether or not the browser's URL carries a trailing slash.
+    # A relative "../../_sidebar.html" depends on document.baseURI, which is
+    # the no-slash URL when Turbo navigates to a leaf via a slash-less nav link,
+    # and then resolves one level too shallow and 404s. The !r.ok guard stops a
+    # 404 response body from being read as text and outerHTML'd into the page
+    # (fetch does not reject on 404; the .catch only covers network errors).
     SIDEBAR_PLACEHOLDER = '<aside id="sidebar" aria-label="Table of Contents" data-static-sidebar-placeholder></aside>'
+
+    def sidebar_fetch_script(book_rel)
+      <<~JS
+        <script>
+        fetch("/#{book_rel}/_sidebar.html").then(function(r){
+        if(!r.ok)return null;
+        return r.text();
+        }).then(function(h){
+        if(!h)return;
+        var p=document.querySelector("aside[data-static-sidebar-placeholder]");
+        if(p)p.outerHTML=h;
+        }).catch(function(){});
+        </script>
+      JS
+    end
 
     Result = Struct.new(:books, :leaves, :assets, :resources, :resource_failures, :bytes, keyword_init: true)
 
@@ -144,7 +164,7 @@ module Writebook
       end
 
       def render(rel, html)
-        html = make_relative(strip_dead_auth_links(html))
+        html = make_relative(neutralize_search_form(strip_dead_auth_links(html)))
         write(rel, html)
         @rendered << [rel, html]
         html
@@ -152,6 +172,14 @@ module Writebook
 
       def strip_dead_auth_links(html)
         html.gsub(AUTH_LINK_PATTERN, "")
+      end
+
+      def neutralize_search_form(html)
+        html.gsub(SEARCH_FORM_PATTERN) do |form|
+          form = form.sub(/\saction="[^"]*"/, "")
+          form = form.sub(/\sdata-turbo="[^"]*"/, "")
+          form.sub(/>/, ' data-turbo="false" onsubmit="return false">')
+        end
       end
 
       # Rewrite absolute URLs to the export host as root-relative so the site is
@@ -234,7 +262,7 @@ module Writebook
         write("#{book_rel}/_sidebar.html", sidebar)
         log "  externalized sidebar -> #{book_rel}/_sidebar.html (#{sidebar.bytesize} bytes)"
 
-        replacement = SIDEBAR_PLACEHOLDER + "\n" + SIDEBAR_FETCH_SCRIPT
+        replacement = SIDEBAR_PLACEHOLDER + "\n" + sidebar_fetch_script(book_rel)
         rendered_index = @rendered.to_h { |rel, html| [rel, html] }
 
         leaf_htmls.each do |rel, html|

--- a/lib/writebook/static_exporter.rb
+++ b/lib/writebook/static_exporter.rb
@@ -1,0 +1,319 @@
+require "uri"
+
+module Writebook
+  # Renders Writebook's read-only views -- the library menu, each book's table of
+  # contents, and every leaf -- to a static directory, along with every asset and
+  # image blob those pages reference. The result can be served by any static web
+  # server with no Rails process, login, or editing machinery.
+  #
+  # Books are rendered exactly as a logged-out visitor sees them. The read
+  # templates already suppress every editing affordance when +book.editable?+ is
+  # false, so no application code is modified. The single login affordance that
+  # remains in that view -- the library's sign-in button -- is stripped from the
+  # output, since it has no destination on a static host. Absolute URLs to the
+  # export host are rewritten to be root-relative so the site is self-contained.
+  #
+  # Resources (compiled assets and image blobs) are resolved two ways:
+  #   * In a deployed instance, +public/assets+ already holds the precompiled
+  #     asset files, so that directory is mirrored directly.
+  #   * Anything referenced by the rendered pages that the mirror did not
+  #     already provide -- e.g. assets served live by Propshaft in development,
+  #     ActiveStorage covers/pictures, and in-body uploads -- is fetched through
+  #     the same integration session that rendered the HTML, so the bytes are
+  #     always whatever a visitor's browser would actually receive.
+  class StaticExporter
+    STATIC_ROOT_FILES = %w[favicon.svg favicon.png app-icon.png app-icon-192.png robots.txt].freeze
+    PWA_PATHS = %w[/manifest.json /manifest].freeze
+
+    # Matches asset, upload, and blob URLs *inside a quoted attribute* (src, href,
+    # data-lightbox-url-value, or the og:image content=), with an optional
+    # absolute host prefix so covers are caught too. Bounding the match to the
+    # closing quote keeps the scan from over-running into adjacent HTML when a
+    # URL sits in unquoted text; only the path (group 1) is captured.
+    RESOURCE_URL_PATTERN = %r{(?:src|href|data-lightbox-url-value|content)\s*=\s*["'](?:https?://[^/]+)?(/(?:assets/[^"']+|u/[^"']+|rails/active_storage/[^"']+))["']}
+
+    # <a> elements pointing at session/user/account or edit paths -- dead links
+    # on a static host. Only the library's sign-in button appears in the
+    # logged-out read views.
+    AUTH_LINK_PATTERN = /<a\s[^>]*href="(?:\/(?:session|users|account)|[^"]*\/edit)[^"]*"[^>]*>.*?<\/a>/m
+
+    # The table-of-contents sidebar embedded in every leaf page. It is
+    # byte-identical across every leaf of a book, so it is externalized once
+    # per book and loaded with a small inline fetch (see +externalize_sidebar+).
+    # No \b word boundaries: a \b immediately after a double quote never
+    # matches, since both sides are non-word characters.
+    SIDEBAR_ASIDE_PATTERN = /<aside\s[^>]*?id="sidebar"[^>]*>.*?<\/aside>/m
+
+    # The inline script that swaps the placeholder <aside> for the shared
+    # sidebar fragment. Two levels up from a leaf's
+    # <book_rel>/<leaf_id>/<leaf_slug>/index.html lands on <book_rel>/.
+    SIDEBAR_FETCH_SCRIPT = <<~JS.freeze
+      <script>
+      fetch("../../_sidebar.html").then(r=>r.text()).then(function(h){
+      var p=document.querySelector("aside[data-static-sidebar-placeholder]");
+      if(p) p.outerHTML=h;
+      }).catch(function(){});
+      </script>
+    JS
+
+    SIDEBAR_PLACEHOLDER = '<aside id="sidebar" aria-label="Table of Contents" data-static-sidebar-placeholder></aside>'
+
+    Result = Struct.new(:books, :leaves, :assets, :resources, :resource_failures, :bytes, keyword_init: true)
+
+    def initialize(output_dir, host: "example.com", protocol: "https", verbose: false)
+      @output_dir = Pathname.new(output_dir)
+      @host = host.to_s
+      @protocol = protocol.to_s
+      @verbose = verbose
+      @rendered = [] # Array of [String rel, String html]
+      @resource_ok = 0
+      @resource_fail = 0
+    end
+
+    def call
+      configure_url_options
+      FileUtils.rm_rf(@output_dir)
+      FileUtils.mkdir_p(@output_dir)
+
+      render_library
+      mirror_precompiled_assets
+      copy_root_files
+      copy_resources
+      fetch_pwa_manifest
+
+      write_manifest
+      Result.new(books: @book_count, leaves: @leaf_count, assets: @asset_count,
+                resources: @resource_ok, resource_failures: @resource_fail, bytes: dir_size)
+    ensure
+      restore_url_options
+    end
+
+    private
+      def session
+        @session ||= begin
+          s = ActionDispatch::Integration::Session.new(Rails.application)
+          s.host = @host
+          s.https! if @protocol == "https"
+          s
+        end
+      end
+
+      def configure_url_options
+        @original_url_options = Rails.application.routes.default_url_options.dup
+        opts = { host: @host, protocol: @protocol }
+        Rails.application.routes.default_url_options.update(opts)
+        ActiveStorage::Current.url_options = opts
+      end
+
+      def restore_url_options
+        Rails.application.routes.default_url_options.clear
+        Rails.application.routes.default_url_options.update(@original_url_options) if @original_url_options
+      end
+
+      def get(path)
+        session.get(path)
+        status = session.response.status
+        raise "GET #{path} returned #{status}\n#{session.response.body[0, 500]}" unless (200..299).cover?(status)
+        session.response.body
+      end
+
+      # Fetches the bytes behind a URL, following ActiveStorage's redirects.
+      # Returns the final 200 body, or +nil+ on failure. Variants are generated
+      # on demand by the request itself.
+      def fetch_bytes(url, redirect_limit = 6)
+        target = url
+        redirect_limit.times do
+          session.get(target)
+          response = session.response
+          return body_bytes(response) if (200..299).cover?(response.status)
+          return nil unless (300..399).cover?(response.status) && response.location
+          target = URI.parse(response.location).request_uri
+        end
+      end
+
+      def body_bytes(response)
+        body = response.body
+        body = Array(body).map(&:to_s).join unless body.is_a?(String)
+        body&.bytesize&.positive? ? body : nil
+      end
+
+      def write(rel, body, binary: false)
+        dest = @output_dir.join(rel)
+        FileUtils.mkdir_p(dest.dirname)
+        binary ? File.binwrite(dest, body) : File.write(dest, body)
+      end
+
+      def render(rel, html)
+        html = make_relative(strip_dead_auth_links(html))
+        write(rel, html)
+        @rendered << [rel, html]
+        html
+      end
+
+      def strip_dead_auth_links(html)
+        html.gsub(AUTH_LINK_PATTERN, "")
+      end
+
+      # Rewrite absolute URLs to the export host as root-relative so the site is
+      # self-contained. External URLs (e.g. once.com) are left untouched. The
+      # optional port covers the :443 Rails appends under https!.
+      def make_relative(html)
+        return html if @host.empty?
+        html.gsub(%r{https?://#{Regexp.escape(@host)}(?::\d+)?}, "")
+      end
+
+      def render_library
+        log "Rendering library index"
+        # Point each library card's bookmark frame at the static directory's
+        # index.html so Turbo loads it without a redirect on the static host
+        # (see +render_bookmark+). Only the library index carries these frames.
+        library_html = rewrite_bookmark_frame_srcs(get("/"))
+        render("index.html", library_html)
+
+        books = Book.published.ordered.to_a
+        @book_count = books.size
+        @leaf_count = 0
+
+        books.each do |book|
+          book_path = "/#{book.id}/#{book.slug}"
+          book_rel  = "#{book.id}/#{book.slug}"
+          log "Book ##{book.id} #{book.title.inspect} -> #{book_rel}/"
+          render("#{book_rel}/index.html", get(book_path))
+          # The book and leaf views each declare a <link rel="alternate"
+          # type="text/markdown" href="….md"> pointing at the front-matter
+          # markdown the app serves via format.md. Render those routes too so
+          # the alternate links resolve on a static host instead of 404ing.
+          render("#{book_rel}.md", get("#{book_path}.md"))
+          render_bookmark(book)
+
+          leaves = book.leaves.active.with_leafables.positioned.to_a
+          leaf_htmls = []
+          leaves.each_with_index do |leaf, index|
+            leaf_rel = "#{book_rel}/#{leaf.id}/#{leaf.slug}"
+            html = render("#{leaf_rel}/index.html", get("#{book_path}/#{leaf.id}/#{leaf.slug}"))
+            render("#{leaf_rel}.md", get("#{book_path}/#{leaf.id}/#{leaf.slug}.md"))
+            leaf_htmls << [ "#{leaf_rel}/index.html", html ]
+            @leaf_count += 1
+            log "  [#{index + 1}/#{leaves.size}] #{leaf.title.inspect}" if @verbose && (index % 50).zero?
+          end
+
+          externalize_sidebar(book_rel, leaf_htmls) unless leaf_htmls.empty?
+        end
+        log "Rendered #{@book_count} #{'book'.pluralize(@book_count)}, #{@leaf_count} #{'leaf'.pluralize(@leaf_count)}"
+      end
+
+      # The library's book cards auto-fetch <tt>/books/:id/bookmark</tt> into a
+      # Turbo frame; the response carries the overlay link that turns a card
+      # into a click target. Render that route per book so the fetch resolves on
+      # a static host instead of 404ing into Turbo's "content missing" fallback.
+      # The file is written under <tt>books/:id/</tt> to match the frame's
+      # <tt>src="/books/:id/bookmark/"</tt> (the route is keyed on the book id,
+      # not its slug), so the static host serves it directly with no redirect.
+      def render_bookmark(book)
+        html = get("/books/#{book.id}/bookmark")
+        render("books/#{book.id}/bookmark/index.html", html)
+      end
+
+      # Rewrite the bookmark frame <tt>src="/books/:id/bookmark"</tt> to a
+      # trailing slash so the browser hits the directory's index.html directly.
+      # The negative lookahead avoids double-slashing an already-rewritten URL.
+      def rewrite_bookmark_frame_srcs(html)
+        html.gsub(%r{src="/books/(\d+)/bookmark"(?!/)}, 'src="/books/\1/bookmark/"')
+      end
+
+      # The leaf sidebar -- the full book table of contents -- is identical in
+      # every leaf of a book. Writing it once per book and loading it with a
+      # tiny inline fetch turns an O(n^2) export (every leaf carries the whole
+      # TOC) into O(n). With JS off the sidebar nav is absent, but the page body
+      # and prev/next navigation still work. This is the only JS the exporter
+      # adds; everything else is Writebook's own.
+      def externalize_sidebar(book_rel, leaf_htmls)
+        sidebar = leaf_htmls.first.last[SIDEBAR_ASIDE_PATTERN]
+        return unless sidebar
+
+        write("#{book_rel}/_sidebar.html", sidebar)
+        log "  externalized sidebar -> #{book_rel}/_sidebar.html (#{sidebar.bytesize} bytes)"
+
+        replacement = SIDEBAR_PLACEHOLDER + "\n" + SIDEBAR_FETCH_SCRIPT
+        rendered_index = @rendered.to_h { |rel, html| [rel, html] }
+
+        leaf_htmls.each do |rel, html|
+          trimmed = html.sub(SIDEBAR_ASIDE_PATTERN, replacement)
+          next if trimmed == html
+          write(rel, trimmed)
+          rendered_index[rel] = trimmed if rendered_index.key?(rel)
+        end
+
+        @rendered = rendered_index.to_a
+      end
+
+      def mirror_precompiled_assets
+        src = Rails.public_path.join("assets")
+        return @asset_count = 0 unless src.directory?
+        FileUtils.cp_r(src, @output_dir.join("assets"))
+        @asset_count = Dir.glob(@output_dir.join("assets", "**", "*").to_s).count { |p| File.file?(p) }
+        log "Mirrored #{@asset_count} precompiled asset files"
+      end
+
+      def copy_root_files
+        STATIC_ROOT_FILES.each do |file|
+          src = Rails.public_path.join(file)
+          FileUtils.cp(src, @output_dir.join(file)) if src.exist?
+        end
+      end
+
+      def copy_resources
+        urls = @rendered.flat_map { |_, html| html.scan(RESOURCE_URL_PATTERN).map(&:first) }.uniq
+        log "Found #{urls.size} referenced #{'resource'.pluralize(urls.size)}" if @verbose
+        urls.each do |url|
+          rel = url.sub(/\?.*\z/, "").sub(%r{^/}, "")
+          next if @output_dir.join(rel).exist? # already satisfied by the precompiled mirror
+          if (bytes = fetch_bytes(url))
+            write(rel, bytes, binary: true)
+            @resource_ok += 1
+          else
+            @resource_fail += 1
+            log "  could not fetch #{url}"
+          end
+        end
+        log "Fetched #{@resource_ok} #{'resource'.pluralize(@resource_ok)}, #{@resource_fail} failed"
+      end
+
+      def fetch_pwa_manifest
+        PWA_PATHS.each do |path|
+          begin
+            write("manifest.json", get(path))
+            log "  fetched #{path} -> manifest.json" if @verbose
+            return
+          rescue => e
+            log "  skipped #{path}: #{e.message}" if @verbose
+          end
+        end
+      end
+
+      def write_manifest
+        @output_dir.join("_static_export_manifest.txt").write(manifest_text)
+      end
+
+      def manifest_text
+        <<~MSG
+          Writebook static export
+          ----------------------
+          host:      #{@host}
+          books:     #{@book_count}
+          leaves:    #{@leaf_count}
+          assets:    #{@asset_count}
+          resources: #{@resource_ok} (failed: #{@resource_fail})
+          size:      #{dir_size}
+        MSG
+      end
+
+      def dir_size
+        `du -sh #{@output_dir}`.strip.split.first
+      end
+
+      def log(message)
+        puts message if @verbose
+      end
+  end
+end

--- a/lib/writebook/static_exporter.rb
+++ b/lib/writebook/static_exporter.rb
@@ -95,7 +95,13 @@ module Writebook
       JS
     end
 
-    Result = Struct.new(:books, :leaves, :assets, :resources, :resource_failures, :bytes, keyword_init: true)
+    # +book_id+ / +book_title+ are set by the controller when a single book is
+    # exported (nil for a whole-library export) so the result and download views
+    # can name the .zip after the book and re-run the same export. The exporter
+    # itself never sets them -- it always renders whatever `Book.published`
+    # currently returns, and the controller scopes that set via a rolled-back
+    # transaction (see StaticExportsController#generate).
+    Result = Struct.new(:books, :leaves, :assets, :resources, :resource_failures, :bytes, :book_id, :book_title, keyword_init: true)
 
     def initialize(output_dir, host: "example.com", protocol: "https", verbose: false)
       @output_dir = Pathname.new(output_dir)

--- a/lib/writebook/static_exporter.rb
+++ b/lib/writebook/static_exporter.rb
@@ -10,8 +10,11 @@ module Writebook
   # templates already suppress every editing affordance when +book.editable?+ is
   # false, so no application code is modified. The single login affordance that
   # remains in that view -- the library's sign-in button -- is stripped from the
-  # output, since it has no destination on a static host. Absolute URLs to the
-  # export host are rewritten to be root-relative so the site is self-contained.
+  # output, since it has no destination on a static host. The search affordance,
+  # whose native backing is server-side FTS5, is rewired to a client-side index
+  # (see +wire_search_form+ and +build_search_index+) so search works with no
+  # Rails process. Absolute URLs to the export host are rewritten to be
+  # root-relative so the site is self-contained.
   #
   # Resources (compiled assets and image blobs) are resolved two ways:
   #   * In a deployed instance, +public/assets+ already holds the precompiled
@@ -37,13 +40,30 @@ module Writebook
     # logged-out read views.
     AUTH_LINK_PATTERN = /<a\s[^>]*href="(?:\/(?:session|users|account)|[^"]*\/edit)[^"]*"[^>]*>.*?<\/a>/m
 
-    # The search dialog's <form id="search_form"> posts to /books/:id/search,
-    # a route that exists only in the live app. On a static host it 404s into
-    # Turbo's "content missing" fallback. Neutralize the form in the export:
-    # drop its action and short-circuit submission (data-turbo="false" makes
-    # Turbo ignore the form; onsubmit="return false" cancels the native submit),
-    # so the dialog still opens for visual parity but no request ever fires.
+    # The search affordance -- the magnifier button plus its <dialog> modal --
+    # is rendered by app/views/books/searches/_search.html.erb into every book
+    # landing and leaf reading header. Native search is server-side: the modal's
+    # <form id="search_form"> posts to /books/:id/search, which runs SQLite FTS5
+    # full-text search (Books::SearchesController#create -> Leaf::Searchable#search
+    # -> the leaf_search_index virtual table) and returns a Turbo-frame fragment.
+    # None of that machinery exists on a static host.
+    #
+    # Rather than strip the affordance (or ship it inert), wire the existing
+    # dialog to a client-side search index: build a per-book _search.json at
+    # export time (see +build_search_index+) from the same title + plain-text
+    # body the FTS index holds, and hand the form to a Stimulus controller
+    # (app/javascript/controllers/static_search_controller.js) that fetches that
+    # index, runs an in-memory search, and renders results into the existing
+    # <turbo-frame id="search"> using the same markup the server would. The live
+    # search UI is untouched; no template changes are made -- only post-
+    # processing on the rendered HTML. See +wire_search_form+.
     SEARCH_FORM_PATTERN = /<form\s[^>]*\bid="search_form"[^>]*>/.freeze
+
+    # A leaf's static path: <book_id>/<book_slug>/<leaf_id>/<leaf_slug>/index.html.
+    # Used to tell leaf pages -- which get the destination-highlight script and
+    # whose search dialog should fetch the per-book index -- from the library
+    # index and the book tables of contents.
+    LEAF_PAGE_PATTERN = /\A\d+\/[^\/]+\/\d+\/[^\/]+\/index\.html\z/
 
     # The table-of-contents sidebar embedded in every leaf page. It is
     # byte-identical across every leaf of a book, so it is externalized once
@@ -187,7 +207,8 @@ module Writebook
       end
 
       def render(rel, html)
-        html = make_relative(neutralize_search_form(strip_dead_auth_links(html)))
+        html = make_relative(wire_search_form(strip_dead_auth_links(html), rel))
+        html = inject_destination_highlight(html) if leaf_page?(rel)
         write(rel, html)
         @rendered << [rel, html]
         html
@@ -197,12 +218,125 @@ module Writebook
         html.gsub(AUTH_LINK_PATTERN, "")
       end
 
-      def neutralize_search_form(html)
+      # Wires the existing search dialog to a client-side search index instead of
+      # the server's POST /books/:id/search, which cannot run on a static host.
+      # The dialog markup (button, <dialog>, <turbo-frame id="search">, and the
+      # empty <form id="search_form">) is left in place; only the form is touched:
+      # its dead +action+ is dropped, and it is handed to the static-search
+      # Stimulus controller (+data-controller="static-search"+) with the relative
+      # path to the per-book index (+data-static-search-index-path+). The path is
+      # RELATIVE to the page's own directory and is resolved by the controller
+      # against +location.pathname+ with the same trailing-slash normalization
+      # as +sidebar_fetch_script+, so the index resolves at a domain root and
+      # under any subpath. It is computed per page (see +search_index_path_for+)
+      # because the dialog appears at two depths: the book table of contents
+      # (<book_rel>/index.html, one level above the index) and leaf pages
+      # (<book_rel>/<leaf_id>/<leaf_slug>/index.html, two levels above). The
+      # controller fetches the index lazily on first interaction, so the per-page
+      # cost is one attribute, not the index bytes. No view template is changed.
+      def wire_search_form(html, rel)
+        path = search_index_path_for(rel)
         html.gsub(SEARCH_FORM_PATTERN) do |form|
           form = form.sub(/\saction="[^"]*"/, "")
           form = form.sub(/\sdata-turbo="[^"]*"/, "")
-          form.sub(/>/, ' data-turbo="false" onsubmit="return false">')
+          form.sub(/>/, %[ data-controller="static-search" data-static-search-index-path="#{path}">])
         end
+      end
+
+      # The relative path from a page's own directory to its book's _search.json,
+      # assuming the client normalizes location.pathname to end in "/" before
+      # resolving (as +sidebar_fetch_script+ does). The index lives at
+      # <book_rel>/_search.json; the page sits at <book_rel>/index.html (depth 0)
+      # or <book_rel>/<leaf_id>/<leaf_slug>/index.html (depth 2), so the relative
+      # climb is one "../" per directory level between the page dir and <book_rel>.
+      # Returns "../../_search.json" for leaves, "_search.json" for a book TOC.
+      def search_index_path_for(rel)
+        segments = rel.split("/")
+        book_rel = segments.first(2).join("/")
+        page_dir = rel.sub(/\/index\.html\z/, "")
+        depth = [0, page_dir.split("/").size - book_rel.split("/").size].max
+        ("../" * depth) + "_search.json"
+      end
+
+      # True for a leaf's static page (<book_id>/<book_slug>/<leaf_id>/<leaf_slug>
+      # /index.html) -- the pages that carry a body to highlight and a search
+      # dialog scoped to the book's index.
+      def leaf_page?(rel)
+        LEAF_PAGE_PATTERN.match?(rel)
+      end
+
+      # Appends the destination-highlight script to leaf pages so arriving via a
+      # search-result link (which carries ?search=<query>) wraps whole-word
+      # matches in <mark> and scrolls the first into view -- mirroring the
+      # server's highlight_searched_content + scroll_to_highlight_controller,
+      # which cannot run on a static host. The exported leaf HTML carries no
+      # baked-in marks (it is fetched without ?search=), so the script only does
+      # work when the live URL carries the query.
+      def inject_destination_highlight(html)
+        return html unless html.include?("</body>")
+        html.sub("</body>", "#{destination_highlight_script}\n</body>")
+      end
+
+      # An inline script run once on load: read ?search=, tokenize to word terms,
+      # walk the section title (<h1> in .page--section) and page body (.page--page)
+      # text nodes, wrap whole-word matches in <mark>, and scroll the first match
+      # into view. Mirrors SearchesHelper#whole_word_matchers (/\bterm\b/, longest
+      # terms first so a longer term wins before a shorter one inside it) and
+      # scroll_to_highlight_controller. No-op when ?search= is absent.
+      def destination_highlight_script
+        <<~JS
+          <script>
+          (function(){
+          var q=new URLSearchParams(location.search).get("search");
+          if(!q)return;
+          var terms=q.split(/[^0-9A-Za-z]+/).filter(Boolean).map(function(t){return t.toLowerCase();});
+          terms=terms.filter(function(t,i){return terms.indexOf(t)===i;});
+          if(!terms.length)return;
+          terms.sort(function(a,b){return b.length-a.length;});
+          var esc=function(s){return s.replace(/[&<>"']/g,function(c){return {"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c];});};
+          var rx=function(s){return s.replace(/[.*+?^${}()|[\\]\\\\]/g,function(m){return "\\\\"+m;});};
+          var roots=[].slice.call(document.querySelectorAll(".page--section, .page--page"));
+          var first=null;
+          roots.forEach(function(root){
+          var tw=document.createTreeWalker(root,NodeFilter.SHOW_TEXT,{acceptNode:function(n){
+          if(!n.nodeValue||!n.nodeValue.trim())return NodeFilter.FILTER_REJECT;
+          return NodeFilter.FILTER_ACCEPT;}});
+          var nodes=[],n;while((n=tw.nextNode()))nodes.push(n);
+          nodes.forEach(function(node){
+          var text=node.nodeValue,html=esc(text),orig=html;
+          terms.forEach(function(term){var e=esc(term);html=html.replace(new RegExp("\\\\b"+rx(e)+"\\\\b","gi"),function(m){return "<mark>"+m+"</mark>";});});
+          if(html===orig)return;
+          var frag=document.createRange().createContextualFragment(html);
+          var m=frag.querySelector("mark");if(m&&!first)first=m;
+          node.parentNode.replaceChild(frag,node);
+          });
+          });
+          if(first)first.scrollIntoView({behavior:"smooth",block:"center"});
+          })();
+          </script>
+        JS
+      end
+
+      # Writes a per-book search index at <book_rel>/_search.json alongside the
+      # externalized _sidebar.html. Each entry carries the leaf's id, slug, title,
+      # its static root-relative URL, and its searchable content -- the same title
+      # + plain-text body the server's FTS index holds (Leaf#title and
+      # Leaf#searchable_content, which delegates to the leafable). The client-side
+      # static_search_controller fetches this lazily on first dialog open and
+      # builds an in-memory inverted index, so the per-page cost stays one
+      # attribute. See +wire_search_form+.
+      def build_search_index(book, book_rel, leaves)
+        return if leaves.empty?
+        write("#{book_rel}/_search.json", search_index_for(book_rel, leaves))
+        log "  wrote search index -> #{book_rel}/_search.json (#{leaves.size} leaves)" if @verbose
+      end
+
+      def search_index_for(book_rel, leaves)
+        JSON.pretty_generate(leaves.map do |leaf|
+          { id: leaf.id, slug: leaf.slug, title: leaf.title.to_s,
+            url: "/#{book_rel}/#{leaf.id}/#{leaf.slug}",
+            content: leaf.searchable_content.to_s }
+        end)
       end
 
       # Rewrite absolute URLs to the export host as root-relative so the site is
@@ -249,6 +383,7 @@ module Writebook
           end
 
           externalize_sidebar(book_rel, leaf_htmls) unless leaf_htmls.empty?
+          build_search_index(book, book_rel, leaves) unless leaf_htmls.empty?
         end
         log "Rendered #{@book_count} #{'book'.pluralize(@book_count)}, #{@leaf_count} #{'leaf'.pluralize(@leaf_count)}"
       end
@@ -276,7 +411,8 @@ module Writebook
       # every leaf of a book. Writing it once per book and loading it with a
       # tiny inline fetch turns an O(n^2) export (every leaf carries the whole
       # TOC) into O(n). With JS off the sidebar nav is absent, but the page body
-      # and prev/next navigation still work. This is the only JS the exporter
+      # and prev/next navigation still work. The destination-highlight script
+      # (+inject_destination_highlight+) is the other inline script the exporter
       # adds; everything else is Writebook's own.
       def externalize_sidebar(book_rel, leaf_htmls)
         sidebar = leaf_htmls.first.last[SIDEBAR_ASIDE_PATTERN]

--- a/test/controllers/static_exports_controller_test.rb
+++ b/test/controllers/static_exports_controller_test.rb
@@ -29,6 +29,48 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
 
     post static_export_url
     assert_response :forbidden
+
+    get static_export_download_url
+    assert_response :forbidden
+
+    get static_site_preview_url
+    assert_response :forbidden
+  end
+
+  test "download and preview require authentication" do
+    get static_export_download_url
+    assert_redirected_to new_session_url
+
+    get static_site_preview_url
+    assert_redirected_to new_session_url
+  end
+
+  test "admin download streams a zip of the generated site" do
+    sign_in :david
+
+    get static_export_download_url
+    assert_response :ok
+    assert_match %r{application/zip}, response.content_type.to_s
+    assert_match "PK", response.body # local-part of a zip file
+  end
+
+  test "admin preview serves the generated index" do
+    sign_in :david
+
+    get static_site_preview_url
+    assert_response :ok
+    assert_match %r{text/html}, response.content_type.to_s
+    assert_match books(:handbook).title, response.body
+  end
+
+  test "admin create with no published books renders the nothing-to-export page" do
+    sign_in :david
+    Book.update_all(published: false)
+
+    post static_export_url
+    assert_response :ok
+    assert_match "Nothing to export", response.body
+    assert_no_match "Your static site is ready", response.body
   end
 
   test "admin show renders the landing page" do

--- a/test/controllers/static_exports_controller_test.rb
+++ b/test/controllers/static_exports_controller_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class StaticExportsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    # The exporter renders Book.published; publish the fixture book so the
+    # generated site has something in it. Start from a clean output dir.
+    books(:handbook).update!(published: true)
+    FileUtils.rm_rf(Rails.root.join("tmp/static-site"))
+  end
+
+  teardown { FileUtils.rm_rf(Rails.root.join("tmp/static-site")) }
+
+  test "show requires authentication" do
+    get static_export_url
+    assert_redirected_to new_session_url
+  end
+
+  test "create requires authentication" do
+    post static_export_url
+    assert_redirected_to new_session_url
+  end
+
+  test "non-admins are forbidden" do
+    sign_in :kevin
+    assert users(:kevin).member?
+
+    get static_export_url
+    assert_response :forbidden
+
+    post static_export_url
+    assert_response :forbidden
+  end
+
+  test "admin show renders the landing page" do
+    sign_in :david
+    assert users(:david).administrator?
+
+    get static_export_url
+    assert_response :ok
+    assert_match "Generate static site", @response.body
+  end
+
+  test "admin create renders the static site and the result page" do
+    sign_in :david
+
+    post static_export_url
+    assert_response :ok
+
+    dir = Rails.root.join("tmp/static-site")
+    assert File.exist?(dir.join("index.html")), "expected the library index"
+
+    book = books(:handbook)
+    # The .md alternate routes are rendered too, so the alternate links resolve
+    # instead of 404ing on the static host.
+    assert File.exist?(dir.join(book.id.to_s, "#{book.slug}.md")),
+      "expected the book markdown alternate"
+    leaf = book.leaves.active.with_leafables.positioned.first
+    assert File.exist?(dir.join(book.id.to_s, book.slug, leaf.id.to_s, "#{leaf.slug}.md")),
+      "expected the leaf markdown alternate"
+
+    assert_match "Your static site is ready", @response.body
+    assert_match "Preview locally", @response.body
+  end
+end

--- a/test/controllers/static_exports_controller_test.rb
+++ b/test/controllers/static_exports_controller_test.rb
@@ -73,6 +73,32 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match "Your static site is ready", response.body
   end
 
+  test "admin create with no books at all renders empty even with drafts requested" do
+    sign_in :david
+    Book.destroy_all
+
+    post static_export_url, params: { include_drafts: "1" }
+    assert_response :ok
+    assert_match "Nothing to export", response.body
+  end
+
+  test "admin create with drafts exports unpublished books and leaves the DB untouched" do
+    sign_in :david
+    books(:handbook).update!(published: false) # nothing published; handbook is now a draft
+
+    post static_export_url, params: { include_drafts: "1" }
+    assert_response :ok
+    assert_match "Your static site is ready", response.body
+
+    dir = Rails.root.join("tmp/static-site")
+    book = books(:handbook)
+    assert File.exist?(dir.join(book.id.to_s, book.slug, "index.html")),
+      "the unpublished draft should have been exported"
+
+    assert_equal false, Book.find(book.id).published,
+      "the live database must be left untouched (draft still unpublished after rollback)"
+  end
+
   test "admin show renders the landing page" do
     sign_in :david
     assert users(:david).administrator?

--- a/test/controllers/static_exports_controller_test.rb
+++ b/test/controllers/static_exports_controller_test.rb
@@ -35,6 +35,9 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
 
     get static_site_preview_url
     assert_response :forbidden
+
+    get static_export_result_url
+    assert_response :forbidden
   end
 
   test "download and preview require authentication" do
@@ -68,6 +71,8 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
     Book.update_all(published: false)
 
     post static_export_url
+    assert_redirected_to static_export_result_url
+    follow_redirect!
     assert_response :ok
     assert_match "Nothing to export", response.body
     assert_no_match "Your static site is ready", response.body
@@ -78,6 +83,8 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
     Book.destroy_all
 
     post static_export_url, params: { include_drafts: "1" }
+    assert_redirected_to static_export_result_url
+    follow_redirect!
     assert_response :ok
     assert_match "Nothing to export", response.body
   end
@@ -87,6 +94,8 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
     books(:handbook).update!(published: false) # nothing published; handbook is now a draft
 
     post static_export_url, params: { include_drafts: "1" }
+    assert_redirected_to static_export_result_url
+    follow_redirect!
     assert_response :ok
     assert_match "Your static site is ready", response.body
 
@@ -112,6 +121,8 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
     sign_in :david
 
     post static_export_url
+    assert_redirected_to static_export_result_url
+    follow_redirect!
     assert_response :ok
 
     dir = Rails.root.join("tmp/static-site")
@@ -128,5 +139,17 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_match "Your static site is ready", @response.body
     assert_match "Preview locally", @response.body
+  end
+
+  test "admin result without a stashed export falls back to the landing page" do
+    sign_in :david
+
+    get static_export_result_url
+    assert_redirected_to static_export_url
+  end
+
+  test "result requires authentication" do
+    get static_export_result_url
+    assert_redirected_to new_session_url
   end
 end

--- a/test/controllers/static_exports_controller_test.rb
+++ b/test/controllers/static_exports_controller_test.rb
@@ -152,4 +152,77 @@ class StaticExportsControllerTest < ActionDispatch::IntegrationTest
     get static_export_result_url
     assert_redirected_to new_session_url
   end
+
+  test "admin show lists every book in the selector" do
+    sign_in :david
+    get static_export_url
+    assert_response :ok
+    assert_match "All published books", @response.body
+    assert_match books(:handbook).title, @response.body
+    assert_match books(:manual).title, @response.body
+  end
+
+  test "admin create with book_id exports only that book and leaves the DB untouched" do
+    sign_in :david
+    books(:handbook).update!(published: true)
+    books(:manual).update!(published: true)
+
+    post static_export_url, params: { book_id: books(:handbook).id }
+    assert_redirected_to static_export_result_url
+    follow_redirect!
+    assert_response :ok
+    assert_match "Your static site is ready", @response.body
+    assert_match books(:handbook).title, @response.body
+
+    dir = Rails.root.join("tmp/static-site")
+    handbook = books(:handbook)
+    manual = books(:manual)
+    assert File.exist?(dir.join(handbook.id.to_s, handbook.slug, "index.html")),
+      "the chosen book should have been exported"
+    refute File.exist?(dir.join(manual.id.to_s, manual.slug, "index.html")),
+      "the other published book should have been excluded"
+
+    # The library menu shows only the chosen book.
+    index = File.read(dir.join("index.html"))
+    assert_match handbook.title, index
+    refute_match manual.title, index
+
+    # Live DB untouched: both books still published after the rollback.
+    assert_equal true, Book.find(handbook.id).published
+    assert_equal true, Book.find(manual.id).published
+  end
+
+  test "admin create with book_id exports a draft and leaves it a draft" do
+    sign_in :david
+    books(:handbook).update!(published: false) # the target is an unpublished draft
+    books(:manual).update!(published: true)    # a published book that must be hidden
+
+    post static_export_url, params: { book_id: books(:handbook).id }
+    follow_redirect!
+    assert_response :ok
+
+    dir = Rails.root.join("tmp/static-site")
+    handbook = books(:handbook)
+    manual = books(:manual)
+    assert File.exist?(dir.join(handbook.id.to_s, handbook.slug, "index.html")),
+      "the chosen draft should be exported even though it isn't published"
+    refute File.exist?(dir.join(manual.id.to_s, manual.slug, "index.html")),
+      "the other published book should have been hidden during the export"
+
+    assert_equal false, Book.find(handbook.id).published,
+      "the live database must be left untouched (target still a draft)"
+    assert_equal true, Book.find(manual.id).published,
+      "the live database must be left untouched (other book still published)"
+  end
+
+  test "admin download with book_id names the zip after the book" do
+    sign_in :david
+    books(:handbook).update!(published: true)
+
+    get static_export_download_url(book_id: books(:handbook).id)
+    assert_response :ok
+    assert_match %r{application/zip}, response.content_type.to_s
+    assert_match "writebook-#{books(:handbook).slug}.zip",
+                 response.headers["Content-Disposition"].to_s
+  end
 end

--- a/test/lib/writebook/static_exporter_test.rb
+++ b/test/lib/writebook/static_exporter_test.rb
@@ -1,0 +1,144 @@
+require "test_helper"
+require "tmpdir"
+
+class Writebook::StaticExporterTest < ActiveSupport::TestCase
+  setup do
+    @dir = Pathname.new(Dir.mktmpdir)
+    # The library shows published books to logged-out visitors.
+    books(:handbook).update!(published: true)
+  end
+
+  teardown { FileUtils.rm_rf(@dir) }
+
+  test "generates the library index, every book, and every leaf" do
+    book = books(:handbook)
+    result = Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    assert File.exist?(@dir.join("index.html"))
+    assert_includes @dir.join("index.html").read, "Handbook"
+
+    book_dir = @dir.join(book.id.to_s, book.slug)
+    assert File.exist?(book_dir.join("index.html")), "expected book table of contents"
+
+    book.leaves.active.with_leafables.positioned.each do |leaf|
+      leaf_file = book_dir.join(leaf.id.to_s, leaf.slug, "index.html")
+      assert File.exist?(leaf_file), "expected leaf #{leaf_file}"
+    end
+
+    assert_equal 1, result.books
+    assert_equal book.leaves.active.count, result.leaves
+  end
+
+  test "copies compiled assets and root static files" do
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    assert File.directory?(@dir.join("assets"))
+    assert_operator Dir.glob(@dir.join("assets", "**", "*.css").to_s).size, :>, 0
+    assert File.exist?(@dir.join("favicon.svg"))
+  end
+
+  test "copies referenced image blobs" do
+    book = books(:handbook)
+    picture = leaves(:reading_picture)
+
+    result = Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    # The picture leaf references an ActiveStorage image; the exporter should
+    # have fetched it and written the bytes into the output tree.
+    picture_html = @dir.join(book.id.to_s, book.slug, picture.id.to_s, picture.slug, "index.html").read
+    assert_match %r{/rails/active_storage/}, picture_html
+
+    copied = Dir.glob(@dir.join("rails", "active_storage", "**", "*").to_s).select { |p| File.file?(p) }
+    assert_operator copied.size, :>, 0, "expected copied image blobs under rails/active_storage"
+    assert_operator File.size(copied.first), :>, 0, "image file should not be empty"
+    assert_equal 0, result.resource_failures, "every referenced resource should be fetched"
+  end
+
+  test "strips the library sign-in link and rewrites host URLs to be relative" do
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    html = @dir.join("index.html").read
+    assert_not_includes html, "/session", "sign-in link should be stripped from the static library"
+    assert_not_includes html, "https://example.com", "host URLs should be rewritten as root-relative"
+  end
+
+  test "renders the bookmark route per book and rewrites the library frame src" do
+    book = books(:handbook)
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    # The bookmark frame the library cards auto-fetch is rendered to a static
+    # file at books/<id>/bookmark/ -- matching the frame's src="/books/<id>/bookmark/"
+    # (the route is keyed on the book id, not its slug) -- so the overlay click
+    # target resolves instead of 404ing.
+    bookmark_file = @dir.join("books", book.id.to_s, "bookmark", "index.html")
+    assert File.exist?(bookmark_file), "expected bookmark file for the library cards"
+
+    bookmark_html = bookmark_file.read
+    assert_includes bookmark_html, "bookmark__link", "bookmark overlay link should be present"
+    assert_includes bookmark_html, "/#{book.id}/#{book.slug}", "bookmark should link to the book"
+
+    # The library index points the frame at the directory (trailing slash) so
+    # the static host serves index.html with no redirect.
+    library_html = @dir.join("index.html").read
+    assert_includes library_html, %(src="/books/#{book.id}/bookmark/"),
+      "library bookmark frame src should point at the static directory"
+    assert_not_includes library_html, %(src="/books/#{book.id}/bookmark"),
+      "library bookmark frame src should not be the bare route"
+  end
+
+  test "externalizes the per-book sidebar into a shared fetched fragment" do
+    book = books(:handbook)
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    book_dir = @dir.join(book.id.to_s, book.slug)
+
+    # The full table of contents is written once per book, not copied into
+    # every leaf.
+    sidebar_file = book_dir.join("_sidebar.html")
+    assert File.exist?(sidebar_file), "expected a shared sidebar fragment per book"
+    sidebar_html = sidebar_file.read
+    assert_includes sidebar_html, %(id="sidebar"), "shared sidebar should keep its aside id"
+    assert_includes sidebar_html, "Summary", "shared sidebar should carry the leaf TOC links"
+
+    # Each leaf carries a placeholder and the inline fetch, not the inline TOC.
+    leaf = book.leaves.active.with_leafables.positioned.first
+    leaf_html = book_dir.join(leaf.id.to_s, leaf.slug, "index.html").read
+    assert_includes leaf_html, "data-static-sidebar-placeholder",
+      "leaf should carry the sidebar placeholder"
+    assert_includes leaf_html, %(fetch("../../_sidebar.html")),
+      "leaf should fetch the shared sidebar two levels up"
+    assert_not_includes leaf_html, %(<menu class="sidebar__content toc),
+      "leaf should not embed the inline table of contents"
+  end
+
+  test "renders the markdown alternate for each book and leaf so the alternate link resolves" do
+    book = books(:handbook)
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    book_dir = @dir.join(book.id.to_s, book.slug)
+
+    # The book view's <link rel="alternate" type="text/markdown"
+    # href="/<id>/<slug>.md"> points at a file that lives next to the book's
+    # own directory.
+    book_md = book_dir.join("../#{book.slug}.md")
+    assert File.exist?(book_md), "expected book markdown alternate #{book_md}"
+    book_md_text = book_md.read
+    assert_match(/\A---/, book_md_text, "book markdown should start with front-matter")
+    assert_match(/^title:/, book_md_text, "book markdown should carry a front-matter title")
+
+    # Each leaf view's alternate points at <id>/<slug>/<leaf_id>/<leaf_slug>.md,
+    # living next to the leaf's <leaf_slug>/ directory.
+    leaf = book.leaves.active.with_leafables.positioned.first
+    leaf_md = book_dir.join(leaf.id.to_s, "#{leaf.slug}.md")
+    assert File.exist?(leaf_md), "expected leaf markdown alternate #{leaf_md}"
+    assert_match(/^url:/, leaf_md.read, "leaf markdown should carry a front-matter url")
+
+    # The href the leaf HTML actually declares must resolve to a real file,
+    # so the alternate link does not 404 on the static host.
+    leaf_html = book_dir.join(leaf.id.to_s, leaf.slug, "index.html").read
+    href = leaf_html[%r{<link rel="alternate"[^>]*href="([^"]+\.md)"}, 1]
+    assert href, "leaf HTML should declare a markdown alternate link"
+    assert File.exist?(@dir.join(href.delete_prefix("/"))),
+      "the declared markdown alternate #{href} should resolve to a static file"
+  end
+end

--- a/test/lib/writebook/static_exporter_test.rb
+++ b/test/lib/writebook/static_exporter_test.rb
@@ -100,13 +100,22 @@ class Writebook::StaticExporterTest < ActiveSupport::TestCase
     assert_includes sidebar_html, %(id="sidebar"), "shared sidebar should keep its aside id"
     assert_includes sidebar_html, "Summary", "shared sidebar should carry the leaf TOC links"
 
-    # Each leaf carries a placeholder and the inline fetch, not the inline TOC.
+    # Each leaf carries a placeholder and a fetch of the shared fragment, not
+    # the inline TOC. The fetch target is relative (../../_sidebar.html) and is
+    # resolved against the leaf's own directory via a pathname normalization, so
+    # the same export works at a domain root and under a subpath. A root-relative
+    # /<book>/<slug>/_sidebar.html would 404 under any subpath, so guard against
+    # regressing to that form.
     leaf = book.leaves.active.with_leafables.positioned.first
     leaf_html = book_dir.join(leaf.id.to_s, leaf.slug, "index.html").read
     assert_includes leaf_html, "data-static-sidebar-placeholder",
       "leaf should carry the sidebar placeholder"
-    assert_includes leaf_html, %(fetch("../../_sidebar.html")),
-      "leaf should fetch the shared sidebar two levels up"
+    assert_includes leaf_html, "../../_sidebar.html",
+      "leaf should fetch the shared sidebar two levels up, relative to the leaf"
+    assert_includes leaf_html, "location.pathname",
+      "leaf should normalize the pathname before resolving the relative fetch"
+    assert_not_includes leaf_html, %(fetch("/#{book.id}/#{book.slug}/_sidebar.html")),
+      "leaf must not use a root-relative sidebar fetch (breaks subpath hosting)"
     assert_not_includes leaf_html, %(<menu class="sidebar__content toc),
       "leaf should not embed the inline table of contents"
   end

--- a/test/lib/writebook/static_exporter_test.rb
+++ b/test/lib/writebook/static_exporter_test.rb
@@ -120,6 +120,82 @@ class Writebook::StaticExporterTest < ActiveSupport::TestCase
       "leaf should not embed the inline table of contents"
   end
 
+  test "writes a per-book search index alongside the sidebar" do
+    book = books(:handbook)
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    book_dir = @dir.join(book.id.to_s, book.slug)
+
+    # The per-book _search.json is written next to _sidebar.html so the client-
+    # side search controller can fetch it with the same relative path the sidebar
+    # fetch uses. It carries each leaf's id, slug, title, static URL, and the
+    # plain-text searchable content the server's FTS index holds.
+    index_file = book_dir.join("_search.json")
+    assert File.exist?(index_file), "expected a per-book search index"
+    entries = JSON.parse(index_file.read)
+    assert_kind_of Array, entries
+    assert_operator entries.size, :>, 0
+
+    entry = entries.first
+    assert_equal %w[id slug title url content].sort, entry.keys.sort
+    leaf = book.leaves.active.with_leafables.positioned.first
+    assert_equal "/#{book.id}/#{book.slug}/#{leaf.id}/#{leaf.slug}", entry["url"]
+    assert_equal leaf.title, entry["title"]
+    # Content is plain text (the FTS index source), never raw HTML or markdown
+    # front-matter.
+    assert_no_match(/<\/?\w+>/, entry["content"], "index content should be plain text")
+    assert_no_match(/\A---/, entry["content"], "index content should not carry front-matter")
+  end
+
+  test "wires the search dialog to a client-side controller instead of neutralizing it" do
+    book = books(:handbook)
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    book_dir = @dir.join(book.id.to_s, book.slug)
+
+    # The search dialog is KEPT (not stripped) and its form is handed to the
+    # static-search Stimulus controller with a relative path to _search.json.
+    # The form is no longer neutralized: no dead action, no onsubmit guard.
+    leaf = book.leaves.active.with_leafables.positioned.first
+    leaf_html = book_dir.join(leaf.id.to_s, leaf.slug, "index.html").read
+    assert_includes leaf_html, %(search__modal), "search modal should be present on leaf pages"
+    assert_includes leaf_html, %(data-controller="static-search"), "form should be wired to the static-search controller"
+    assert_includes leaf_html, %(data-static-search-index-path="../../_search.json"),
+      "leaf form should point at the book index two levels up"
+    assert_no_match(/<form[^>]*id="search_form"[^>]*action=/, leaf_html,
+      "form should have no dead action")
+    assert_not_includes leaf_html, %(onsubmit="return false"), "form must not be neutralized"
+
+    # The book table of contents also carries the dialog, but one level closer
+    # to the index, so its index path is bare.
+    book_html = book_dir.join("index.html").read
+    assert_includes book_html, %(data-controller="static-search")
+    assert_includes book_html, %(data-static-search-index-path="_search.json"),
+      "book TOC form should point at the index in the same directory"
+  end
+
+  test "injects the destination-highlight script into leaf pages only" do
+    book = books(:handbook)
+    Writebook::StaticExporter.new(@dir, host: "example.com").call
+
+    book_dir = @dir.join(book.id.to_s, book.slug)
+
+    # The highlight script runs on leaf pages, reading ?search= from the URL and
+    # wrapping whole-word matches in <mark>. It must read the query param and
+    # target the section/page body containers.
+    leaf = book.leaves.active.with_leafables.positioned.first
+    leaf_html = book_dir.join(leaf.id.to_s, leaf.slug, "index.html").read
+    assert_includes leaf_html, "URLSearchParams(location.search)", "highlight script should read ?search="
+    assert_includes leaf_html, "page--section", "highlight script should target section/page containers"
+    assert_includes leaf_html, "scrollIntoView", "highlight script should scroll to the first match"
+
+    # Non-leaf pages (the book TOC) carry the search dialog but no body to
+    # highlight, so the script is not injected there.
+    book_html = book_dir.join("index.html").read
+    assert_not_includes book_html, "URLSearchParams(location.search)",
+      "highlight script should only be injected into leaf pages"
+  end
+
   test "renders the markdown alternate for each book and leaf so the alternate link resolves" do
     book = books(:handbook)
     Writebook::StaticExporter.new(@dir, host: "example.com").call


### PR DESCRIPTION
## Add a static site generator with client-side search

This adds a self-contained **static site generator** to Writebook: it renders the
public library — the menu of books, every book's table of contents, and every
leaf — to a hostable static HTML directory with all CSS/JS assets and image
blobs copied in, and **no Rails process, login, or editing machinery**. A
hosted export behaves like a read-only visitor: the same bytes, no server.

On top of that, it adds **client-side search** for the static export, so a static
copy can be searched with no Rails process at all — mirroring Writebook's own
server-side SQLite FTS5 search.

The live app is untouched. The exporter renders the read views logged-out
through an `Integration::Session` and post-processes the result, so no
application or template code is modified for the export path.

### Summary

- **Export the whole library to a static site.** Renders the read views exactly
  as a visitor sees them — the library menu, every book TOC, every leaf, the
  bookmark overlay frames, front-matter `.md` alternates, the PWA manifest, and
  every referenced asset and image blob (ActiveStorage covers/pictures + `/u/`
  uploads) — and writes it all to one self-contained directory you can host
  anywhere. Driven by `Writebook::StaticExporter` in
  `lib/writebook/static_exporter.rb`.

- **Make the export dramatically smaller.** The sidebar was previously inlined
  into every leaf — O(n²) bytes, so a 1255-leaf book was ~390 MB. It's now one
  fetched fragment per book (O(n); that book drops to ~39 MB). The fetch
  resolves against `location.pathname` with trailing-slash normalization, so the
  same export works at a domain root and under any subpath (the in-app
  `/static-site/` preview, a GitHub Pages project site, any `/repo/` prefix).

- **Report to the operator in a browser, not to a developer over a shell.** The
  old result page showed a server filesystem path, a shell command, and a server
  log — useless on a Dockerized deploy where `tmp/static-site` lives in a
  container the admin has no shell for. The result page now streams the generated
  site as a single `.zip` (`#download`), serves it in-browser under
  `/static-site/` admin-gated (`#preview`) so it can be seen with no separate web
  server, and renders a distinct "Nothing to export yet" page when there are no
  published books instead of zeroed counts.

- **Don't 500 the result page during export.** The export renders every page
  through a nested request, and that nested request was wiping the live
  request's session state — so the result page crashed in Puma (it passed in the
  test suite because tests scope that state differently than Puma does). Run the
  export in a separate thread wrapped in `Rails.application.executor` so the
  nested request's state stays isolated; the thread is joined, so the request is
  still synchronous. The landing page's "Include unpublished drafts" checkbox
  runs the same rolled-back `Book.transaction` the `STATIC_ALL=1` rake task uses,
  so the live DB is never mutated.

- **Export a single book, not just the whole library.** The landing page gets a
  scope selector: all published books, or one book picked from a list. The
  exporter itself is unchanged (it always renders whatever `Book.published`
  returns); the controller scopes that set inside a rolled-back transaction by
  temporarily making the chosen book the only published one. Handy for sharing
  or hosting a single title.

- **Make search work on a static host.** Native Writebook search is server-side
  FTS5 (`POST /books/:id/search` → `Books::SearchesController#create` → the
  `leaf_search_index` virtual table), which can't run without Rails. The exporter
  previously "neutralized" the search form — stripped its action and short-circuited
  submit — leaving a dialog that opened but did nothing. This replaces that with
  a real client-side search that mirrors the server's behavior, with no view-template
  changes: only post-processing on the rendered HTML plus one new Stimulus
  controller (`app/javascript/controllers/static_search_controller.js`).

  How it stays faithful: a per-book `_search.json` index (title + plain-text
  `searchable_content` — the same fields the FTS index holds) is written
  alongside `_sidebar.html` at export time. The existing search dialog is reused;
  its empty `<form id="search_form">` is handed to a `static-search` controller
  with the relative path to the book's `_search.json`. The controller fetches the
  index lazily on first interaction, builds an in-memory inverted index, and on
  submit renders up to 50 results into the existing `<turbo-frame id="search">`
  using the server's `_results/_result` markup: title with `<mark>`, a ~20-token
  content snippet with `<mark>`, a reading-mode link carrying `?search=`, and a
  "No matches." empty state. Title hits weighted 2×, mirroring
  `bm25(leaf_search_index, 2.0)`. No vendored dependency — a hand-rolled index
  matches the fork's no-bundler, inline-script convention.

  A small inline highlight script is injected into leaf pages so arriving from a
  result link (which carries `?search=`) wraps whole-word matches in `<mark>`
  and scrolls the first into view, mirroring the server's
  `highlight_searched_content` + `scroll_to_highlight_controller`. Exported leaf
  HTML has no baked-in marks; the script only runs when the live URL carries the
  query.

### What's left out (and why)

A static export is read-only by design, so anything that needs a Rails process
or a logged-in session is intentionally absent from the export — and because the
live app is unchanged, none of it is lost:

- **Login / editing / admin.** The export renders the read views logged-out.
  Drafts can be included via the checkbox, which uses a rolled-back transaction
  so the live DB is never mutated.
- **Server-side FTS5 search.** Replaced, not removed: the client-side index
  carries the same `title` + `searchable_content` the FTS index holds, ranked the
  same way (title 2×). The live search UI and server code are untouched; the
  `static-search` controller is eager-loaded in the live app too but only
  activates where `data-controller="static-search"` is present, which the
  exporter injects solely into exported pages.
- **Turbo Drive on the export.** Exported pages are plain HTML served from a
  static host; the search form uses `data-turbo="false"` so no request fires.

### Test plan

- `bin/rails test` — **186 runs, 709 assertions, 0 failures, 0 errors, 0 skips**
  on the branch tip, run in the `ghcr.io/razodin137/writebook:static-search`
  container. New coverage lives in
  `test/controllers/static_exports_controller_test.rb` and
  `test/lib/writebook/static_exporter_test.rb` (exporter tests run in-container
  against the real rendered output), including: drafts export (asserts the draft
  is exported **and** still unpublished in the DB after rollback), the
  no-books-at-all empty case, the single-book scope, and the PRG redirect that
  fixes the Generate form's Turbo error.
- Manually: exported the full library and a single book from the admin "Export
  to static site" button; downloaded the `.zip`; previewed under `/static-site/`;
  opened the search dialog on an exported page and ran a query (title + snippet
  results with `<mark>`, "No matches." empty state); followed a result link and
  confirmed destination highlighting + scroll; confirmed the same export renders
  correctly at a domain root and under a subpath.

### Screenshots

<p>
<img src="https://raw.githubusercontent.com/razodin137/writebook/static-search-assets/screenshots/per-book-select.jpg" alt="Export landing page with the all-books / single-book scope selector and drafts checkbox" width="720">
<br><em>The export landing page: all-books / single-book scope selector, "Include unpublished drafts" checkbox, Generate button.</em>
</p>

<p>
<img src="https://raw.githubusercontent.com/razodin137/writebook/static-search-assets/screenshots/static-export-adminpage.jpg" alt="Admin Export to static site page" width="720">
<br><em>The admin "Export to static site" page.</em>
</p>

<p>
<img src="https://raw.githubusercontent.com/razodin137/writebook/static-search-assets/screenshots/zip-and-preview-menu.jpg" alt="Export result page with Download .zip and Preview buttons" width="720">
<br><em>Result page after Generate: counts, hosting next steps, and the Download .zip / Preview buttons.</em>
</p>

<p>
<img src="https://raw.githubusercontent.com/razodin137/writebook/static-search-assets/screenshots/static-search.jpg" alt="Client-side search dialog on a static export, showing results with highlighted snippets" width="720">
<br><em>Client-side search on a static export — title + snippet results with <code>&lt;mark&gt;</code> highlights, no Rails process.</em>
</p>

### Files

- `lib/writebook/static_exporter.rb` — the exporter (506 lines).
- `app/controllers/static_exports_controller.rb` — admin-gated export / download
  / preview / result, PRG redirect, single-book scope, drafts checkbox.
- `app/javascript/controllers/static_search_controller.js` — client-side search
  Stimulus controller (inverted index, ≤50 results, server's result markup).
- `app/views/static_exports/{create,empty,show}.html.erb` — landing / result /
  empty pages.
- `app/views/books/{index,show}.html.erb` — the download icon in the library
  header; one stray-quote fix.
- `config/routes.rb`, `lib/tasks/static.rake` — routes; `bin/rails static:generate`
  with `STATIC_HOST` / `STATIC_ALL` env support.
- `README.md`, `STATIC_SITE_GENERATOR.md` — docs.
- `test/controllers/static_exports_controller_test.rb`,
  `test/lib/writebook/static_exporter_test.rb` — coverage.

14 files changed, +1784 / −1.

---

Drafted with assistance from Claude Code.