### PR TITLE
Fix version badge for non-Docker installs

### DIFF
--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,2 +1,9 @@
-Rails.application.config.app_version = ENV.fetch("APP_VERSION", "0")
+Rails.application.config.app_version = ENV.fetch("APP_VERSION") do
+  version_file = Rails.root.join("VERSION")
+  if version_file.exist?
+    version_file.read.strip
+  else
+    `git describe --tags --always 2>/dev/null`.strip.presence || "0"
+  end
+end
 Rails.application.config.git_revision = ENV["GIT_REVISION"]

--- a/test/helpers/version_helper_test.rb
+++ b/test/helpers/version_helper_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class VersionHelperTest < ActionView::TestCase
+  def setup
+    @original_app_version = Rails.application.config.app_version
+  end
+
+  def teardown
+    Rails.application.config.app_version = @original_app_version
+  end
+
+  test "version_badge renders the app version in a span" do
+    Rails.application.config.app_version = "1.2.0"
+    assert_equal '<span class="product__version-badge">1.2.0</span>', version_badge
+  end
+
+  test "version_badge renders fallback zero when no version is set" do
+    Rails.application.config.app_version = "0"
+    assert_equal '<span class="product__version-badge">0</span>', version_badge
+  end
+end


### PR DESCRIPTION
The version badge fell back to "0" whenever `APP_VERSION` wasn't set as an env var, which happens for fresh clones without a tagged release.

Fall back through a `VERSION` file and `git describe --tags --always` before reaching "0".

Fixes #447.