### PR TITLE
Serve custom styles from a dedicated text/css route

### DIFF
--- a/app/controllers/accounts/custom_styles_controller.rb
+++ b/app/controllers/accounts/custom_styles_controller.rb
@@ -1,5 +1,13 @@
 class Accounts::CustomStylesController < ApplicationController
-  before_action :ensure_can_administer, :set_account
+  allow_unauthenticated_access only: :show
+  before_action :ensure_can_administer, :set_account, except: :show
+
+  def show
+    if stale? Current.account
+      expires_in 1.hour, public: true
+      render plain: Current.account&.custom_styles.to_s, content_type: "text/css"
+    end
+  end
 
   def edit
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,10 +6,4 @@ module ApplicationHelper
       }
     CSS
   end
-
-  def custom_styles_tag
-    if custom_styles = Current.account&.custom_styles
-      tag.style(custom_styles.to_s.html_safe, data: { turbo_track: "reload" })
-    end
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
     <link rel="apple-touch-icon" href="/app-icon.png">
 
     <%= stylesheet_link_tag :all, "data-turbo-track": "reload" %>
-    <%= custom_styles_tag %>
+    <%= tag.link rel: "stylesheet", href: account_custom_styles_path(v: Current.account&.updated_at&.to_fs(:number)), data: { turbo_track: "reload" } %>
 
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
     <link rel="apple-touch-icon" href="/app-icon.png">
 
     <%= stylesheet_link_tag :all, "data-turbo-track": "reload" %>
-    <%= tag.link rel: "stylesheet", href: account_custom_styles_path(v: Current.account&.updated_at&.to_fs(:number)), data: { turbo_track: "reload" } %>
+    <%= tag.link rel: "stylesheet", href: account_custom_styles_path(v: Current.account&.updated_at&.to_fs(:usec)), data: { turbo_track: "reload" } %>
 
     <%= javascript_importmap_tags %>
   </head>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   resource :account do
     scope module: "accounts" do
       resource :join_code, only: :create
-      resource :custom_styles, only: %i[ edit update ]
+      resource :custom_styles, only: %i[ show edit update ]
     end
   end
 

--- a/test/controllers/custom_styles_controller_test.rb
+++ b/test/controllers/custom_styles_controller_test.rb
@@ -5,6 +5,33 @@ class Accounts::CustomStylesControllerTest < ActionDispatch::IntegrationTest
     sign_in :david
   end
 
+  test "show serves custom styles as plain CSS" do
+    accounts(:signal).update! custom_styles: ":root { --color-text: red; }"
+
+    get account_custom_styles_url
+    assert_response :ok
+    assert_equal "text/css", @response.media_type
+    assert_equal ":root { --color-text: red; }", @response.body
+  end
+
+  test "show is accessible without authentication" do
+    sign_out
+
+    get account_custom_styles_url
+    assert_response :ok
+    assert_equal "text/css", @response.media_type
+  end
+
+  test "show serves markup verbatim as inert CSS text, never HTML" do
+    payload = "</style><script>alert(1)</script>"
+    accounts(:signal).update! custom_styles: payload
+
+    get account_custom_styles_url
+    assert_response :ok
+    assert_equal "text/css", @response.media_type
+    assert_equal payload, @response.body
+  end
+
   test "edit" do
     get edit_account_custom_styles_url
     assert_response :ok

--- a/test/controllers/custom_styles_controller_test.rb
+++ b/test/controllers/custom_styles_controller_test.rb
@@ -8,7 +8,7 @@ class Accounts::CustomStylesControllerTest < ActionDispatch::IntegrationTest
   test "show serves custom styles as plain CSS" do
     accounts(:signal).update! custom_styles: ":root { --color-text: red; }"
 
-    get account_custom_styles_url
+    get account_custom_styles_path
     assert_response :ok
     assert_equal "text/css", @response.media_type
     assert_equal ":root { --color-text: red; }", @response.body
@@ -17,7 +17,7 @@ class Accounts::CustomStylesControllerTest < ActionDispatch::IntegrationTest
   test "show is accessible without authentication" do
     sign_out
 
-    get account_custom_styles_url
+    get account_custom_styles_path
     assert_response :ok
     assert_equal "text/css", @response.media_type
   end
@@ -26,10 +26,23 @@ class Accounts::CustomStylesControllerTest < ActionDispatch::IntegrationTest
     payload = "</style><script>alert(1)</script>"
     accounts(:signal).update! custom_styles: payload
 
-    get account_custom_styles_url
+    get account_custom_styles_path
     assert_response :ok
     assert_equal "text/css", @response.media_type
     assert_equal payload, @response.body
+  end
+
+  test "show is publicly cacheable and honors conditional requests" do
+    accounts(:signal).update! custom_styles: ":root { --color-text: red; }"
+
+    get account_custom_styles_path
+    assert_response :ok
+    assert_includes @response.headers["Cache-Control"], "public"
+    assert_includes @response.headers["Cache-Control"], "max-age=3600"
+    assert_not_nil @response.headers["ETag"]
+
+    get account_custom_styles_path, headers: { "If-None-Match" => @response.headers["ETag"] }
+    assert_response :not_modified
   end
 
   test "edit" do

--- a/test/system/custom_styles_xss_test.rb
+++ b/test/system/custom_styles_xss_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class CustomStylesXssTest < ApplicationSystemTestCase
+  # A stored payload that breaks out of an inline <style> context and executes
+  # as HTML. Rendered inline (the old behavior) this <script> runs and sets the
+  # flag; delivered as an external text/css stylesheet it is inert text.
+  PAYLOAD = %(</style><script>window.__xss_fired = true</script>)
+
+  setup do
+    accounts(:signal).update!(custom_styles: PAYLOAD)
+    sign_in "kevin@example.com"
+  end
+
+  test "custom styles payload loads as a stylesheet and never executes" do
+    visit root_url
+
+    # (a) custom styles arrive via an external stylesheet link, not inline markup
+    assert_selector "link[rel='stylesheet'][href*='custom_styles']", visible: false
+
+    # (b) the payload's <script> never executed — no breakout from CSS context
+    assert_nil evaluate_script("window.__xss_fired")
+
+    # (b') and it injected no live <script> element into the document
+    assert_no_selector "script", text: "__xss_fired", visible: false
+
+    # (c) the browser fetched the payload verbatim as text/css, so it is styled,
+    #     never parsed as HTML
+    fetched = page.evaluate_async_script(<<~JS)
+      var done = arguments[arguments.length - 1];
+      var href = document.querySelector("link[rel='stylesheet'][href*='custom_styles']").href;
+      fetch(href).then(function(r) {
+        return r.text().then(function(body) {
+          done({ type: r.headers.get("content-type"), body: body });
+        });
+      });
+    JS
+
+    assert_includes fetched["type"], "text/css"
+    assert_includes fetched["body"], PAYLOAD
+  end
+end


### PR DESCRIPTION
## Finding

Admin-authored `Account#custom_styles` is rendered inline into every page by `custom_styles_tag`, which marks the raw value `html_safe` inside a `<style>` element. Because the value lands in an HTML context, a stored payload of

```
</style><script>alert(1)</script>
```

closes the style element and executes as script — a verified stored XSS (campaign finding WB-3). Writebook serves published books to unauthenticated readers, so the payload reaches every public visitor, not just signed-in users.

## Fix

Move the styles off the HTML page entirely, so there is no HTML context to break out of:

- `Accounts::CustomStyles#show` (public, like books) renders `custom_styles` verbatim as `text/css`, with an ETag on the account and `expires_in 1.hour, public: true` — caching modeled on `QrCodeController`.
- The layout replaces the inline `<style>` with `<link rel="stylesheet" data-turbo-track="reload">`, cache-busted with `v=account.updated_at` (the `fresh_account_logo` idiom from Campfire) so edits show up immediately.
- The dead `custom_styles_tag` helper is removed. `hide_from_user_style_tag` is untouched — it is per-user, fully app-controlled CSS.

Capability-preserving: admins author exactly the same CSS; only the transport changes. In a `text/css` document, markup is inert text — the breakout is closed by construction rather than by filtering.

Part of the stored-XSS eradication campaign covering ONCE apps (companion PR in once-campfire).

## Verification

- `bin/rails runner 'Rails.application.routes.recognize_path("/account/custom_styles", method: :get)'` → `accounts/custom_styles#show`
- New controller tests: response is `text/css`; the `</style><script>` payload is served byte-for-byte verbatim as CSS text; route is reachable without authentication.
- Full test suite: 196 runs, 0 failures, 0 errors (1 pre-existing skip).