### PR TITLE
Narrow authored iframe embeds to an approved-provider allowlist

### DIFF
--- a/app/models/html_scrubber.rb
+++ b/app/models/html_scrubber.rb
@@ -54,10 +54,13 @@ class HtmlScrubber < Rails::Html::PermitScrubber
       end
     end
 
+    # Keep the whole directive, not just its feature name: `autoplay 'none'`
+    # truncated to `autoplay` would grant a capability the author explicitly
+    # withheld.
     def filtered_allow(value)
       value.to_s.split(";")
-        .map { |directive| directive.strip.split(/\s+/).first.to_s.downcase }
-        .select { |token| IFRAME_ALLOW_TOKENS.include?(token) }
+        .map { |directive| directive.strip }
+        .select { |directive| IFRAME_ALLOW_TOKENS.include?(directive.split(/\s+/).first.to_s.downcase) }
         .uniq
         .join("; ")
     end

--- a/app/models/html_scrubber.rb
+++ b/app/models/html_scrubber.rb
@@ -1,8 +1,64 @@
 class HtmlScrubber < Rails::Html::PermitScrubber
+  # Attributes preserved on a surviving <iframe>. Everything else — srcdoc, on*
+  # handlers, name, sandbox overrides, arbitrary allow — is dropped so only the
+  # vetted embed shape survives. See EmbedAllowlist for the host allowlist.
+  IFRAME_ATTRIBUTES = %w[ src width height allowfullscreen loading referrerpolicy title frameborder allow ].freeze
+
+  # Feature-policy tokens permitted in a surviving iframe `allow` attribute. Any
+  # other requested capability (camera, microphone, geolocation, …) is dropped.
+  IFRAME_ALLOW_TOKENS = %w[
+    accelerometer autoplay clipboard-write encrypted-media fullscreen
+    gyroscope picture-in-picture web-share
+  ].freeze
+
   def initialize
     super
     self.tags = Rails::Html::WhiteListSanitizer.allowed_tags + %w[
       audio details summary iframe options table tbody td th thead tr video source mark
     ]
   end
+
+  # Keep an <iframe> only when its src host is on the embed allowlist; other tags
+  # fall through to the permitted-tag check.
+  def keep_node?(node)
+    if iframe?(node)
+      EmbedAllowlist.allows?(node["src"])
+    else
+      super
+    end
+  end
+
+  # Minimize a surviving <iframe> to the vetted attribute set; other tags keep
+  # the default attribute scrubbing.
+  def scrub_attributes(node)
+    if iframe?(node)
+      minimize_iframe(node)
+    else
+      super
+    end
+  end
+
+  private
+    def iframe?(node)
+      node.element? && node.name == "iframe"
+    end
+
+    def minimize_iframe(node)
+      node.attribute_nodes.each do |attr|
+        name = attr.name.downcase
+        if IFRAME_ATTRIBUTES.include?(name)
+          node[attr.name] = filtered_allow(attr.value) if name == "allow"
+        else
+          attr.remove
+        end
+      end
+    end
+
+    def filtered_allow(value)
+      value.to_s.split(";")
+        .map { |directive| directive.strip.split(/\s+/).first.to_s.downcase }
+        .select { |token| IFRAME_ALLOW_TOKENS.include?(token) }
+        .uniq
+        .join("; ")
+    end
 end

--- a/app/models/html_scrubber.rb
+++ b/app/models/html_scrubber.rb
@@ -1,14 +1,23 @@
 class HtmlScrubber < Rails::Html::PermitScrubber
   # Attributes preserved on a surviving <iframe>. Everything else — srcdoc, on*
-  # handlers, name, sandbox overrides, arbitrary allow — is dropped so only the
-  # vetted embed shape survives. See EmbedAllowlist for the host allowlist.
-  IFRAME_ATTRIBUTES = %w[ src width height allowfullscreen loading referrerpolicy title frameborder allow ].freeze
+  # handlers, name — is dropped so only the vetted embed shape survives. An
+  # authored sandbox is kept: the attribute can only ever remove privileges
+  # relative to no attribute at all, so honoring it never widens anything.
+  # See EmbedAllowlist for the host allowlist.
+  IFRAME_ATTRIBUTES = %w[ src width height allowfullscreen loading referrerpolicy sandbox title frameborder allow ].freeze
 
   # Feature-policy tokens permitted in a surviving iframe `allow` attribute. Any
   # other requested capability (camera, microphone, geolocation, …) is dropped.
   IFRAME_ALLOW_TOKENS = %w[
     accelerometer autoplay clipboard-write encrypted-media fullscreen
     gyroscope picture-in-picture web-share
+  ].freeze
+
+  # referrerpolicy values that don't leak the reader's full URL to the embed
+  # provider; unsafe-url and the downgrade-tolerant default are dropped.
+  IFRAME_REFERRER_POLICIES = %w[
+    no-referrer origin origin-when-cross-origin same-origin
+    strict-origin strict-origin-when-cross-origin
   ].freeze
 
   def initialize
@@ -47,11 +56,18 @@ class HtmlScrubber < Rails::Html::PermitScrubber
       node.attribute_nodes.each do |attr|
         name = attr.name.downcase
         if IFRAME_ATTRIBUTES.include?(name)
-          node[attr.name] = filtered_allow(attr.value) if name == "allow"
+          case name
+          when "allow"          then node[attr.name] = filtered_allow(attr.value)
+          when "referrerpolicy" then filter_referrerpolicy(node, attr)
+          end
         else
           attr.remove
         end
       end
+    end
+
+    def filter_referrerpolicy(node, attr)
+      attr.remove unless IFRAME_REFERRER_POLICIES.include?(attr.value.to_s.strip.downcase)
     end
 
     # Keep the whole directive, not just its feature name: `autoplay 'none'`

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -204,11 +204,13 @@ module EmbedAllowlist
       # scheme-only or keyword token — returns nil: stripping the qualifier
       # would make the scrubber accept more than the CSP source actually
       # allows, so such sources feed frame-src only and admit no iframes.
+      # An explicit :443 IS a plain https origin (CSP matches it like an
+      # omitted port), so it is normalized away rather than rejected.
       def host_from_source(source)
         token = source.to_s.strip
         return nil if token.start_with?("'")
 
-        token = token.delete_prefix("https://").delete_prefix("http://")
+        token = token.delete_prefix("https://").delete_prefix("http://").delete_suffix(":443")
         if token.blank? || token.include?("/") || token.include?(":")
           nil
         else

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -205,12 +205,14 @@ module EmbedAllowlist
       # would make the scrubber accept more than the CSP source actually
       # allows, so such sources feed frame-src only and admit no iframes.
       # An explicit :443 IS a plain https origin (CSP matches it like an
-      # omitted port), so it is normalized away rather than rejected.
+      # omitted port), and a bare trailing slash IS the whole host (a CSP root
+      # path matches every path), so both are normalized away rather than
+      # rejected.
       def host_from_source(source)
         token = source.to_s.strip
         return nil if token.start_with?("'")
 
-        token = token.delete_prefix("https://").delete_prefix("http://").delete_suffix(":443")
+        token = token.delete_prefix("https://").delete_prefix("http://").delete_suffix("/").delete_suffix(":443")
         if token.blank? || token.include?("/") || token.include?(":")
           nil
         else

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -150,10 +150,14 @@ module EmbedAllowlist
       (default_hosts + extra_hosts).uniq
     end
 
-    # True when +src+ is an https URL whose host is on the allowlist.
+    # True when +src+ is an https URL, on the default port, whose host is on
+    # the allowlist. A non-default port must be rejected here because the CSP
+    # sources carry no port — and a portless CSP source matches only the
+    # scheme's default port, so a kept iframe on :8443 would be one the
+    # browser then refuses to load.
     def allows?(src)
       uri = parse(src)
-      return false unless uri && ALLOWED_SCHEMES.include?(uri.scheme) && uri.host.present?
+      return false unless uri && ALLOWED_SCHEMES.include?(uri.scheme) && uri.host.present? && uri.port == uri.default_port
 
       host = uri.host.downcase
       hosts.any? { |pattern| host_matches?(host, pattern) }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -110,10 +110,11 @@ end
 # Single source of truth for which iframe embed providers Writebook permits.
 #
 # Consumed at two enforcement points that must never disagree:
-#   - author-time, by HtmlScrubber, which strips any <iframe> whose src host is
-#     not on this list before the page is stored/rendered; and
-#   - render-time, by the CSP frame-src directive below, which refuses to load a
-#     frame from an origin not on this list.
+#   - display-time, by HtmlScrubber, which strips any <iframe> whose src host is
+#     not on this list every time page content renders — stored Markdown stays
+#     raw, so the list applies retroactively to existing content; and
+#   - browser-side, by the CSP frame-src directive below, which refuses to load
+#     a frame from an origin not on this list.
 # Both derive their host set from here, so an operator who adds a provider gets
 # it honored in both places from one change.
 #
@@ -130,9 +131,9 @@ end
 # an owner must confirm before this enforces. Set DEFAULT_PROVIDERS to {} to ship
 # with no built-in providers.
 module EmbedAllowlist
-  # Provider name => host matcher(s). A leading "*." matches the apex and any
-  # subdomain (e.g. "*.vimeo.com" matches "vimeo.com" and "player.vimeo.com").
-  # Product-owned default list — curate before enforcing.
+  # Provider name => host matcher(s). A leading "*." matches any subdomain but
+  # not the apex, mirroring CSP host-source semantics — list the apex separately
+  # when both are wanted. Product-owned default list — curate before enforcing.
   DEFAULT_PROVIDERS = {
     "YouTube"     => %w[ www.youtube.com youtube.com www.youtube-nocookie.com ],
     "Vimeo"       => %w[ player.vimeo.com ],
@@ -181,25 +182,34 @@ module EmbedAllowlist
         nil
       end
 
+      # Mirrors CSP host-source semantics: a "*." pattern covers subdomains
+      # only, never the apex, so the scrubber keeps exactly the frames the
+      # frame-src directive will load.
       def host_matches?(host, pattern)
         pattern = pattern.downcase
         if pattern.start_with?("*.")
-          apex = pattern.delete_prefix("*.")
-          host == apex || host.end_with?(".#{apex}")
+          host.end_with?(pattern.delete_prefix("*"))
         else
           host == pattern
         end
       end
 
-      # Extract a bare host from a CSP source expression: "https://www.youtube.com"
-      # or "https://*.vimeo.com/embed" => "www.youtube.com" / "*.vimeo.com". Returns
-      # nil for scheme-only or keyword tokens (:self, https:, 'unsafe-inline', a
-      # host:port) that carry no plain host to match an iframe src against.
+      # Extract a host from a CSP source expression the scrubber can honor
+      # faithfully: "https://www.youtube.com" or "https://*.vimeo.com". Anything
+      # narrower or stranger than a plain https origin — a path, a port, a
+      # scheme-only or keyword token — returns nil: stripping the qualifier
+      # would make the scrubber accept more than the CSP source actually
+      # allows, so such sources feed frame-src only and admit no iframes.
       def host_from_source(source)
-        token = source.to_s.strip.delete_prefix("https://").delete_prefix("http://")
-        token = token.split("/").first.to_s
-        return nil if token.blank? || token.include?(":") || token.start_with?("'")
-        token
+        token = source.to_s.strip
+        return nil if token.start_with?("'")
+
+        token = token.delete_prefix("https://").delete_prefix("http://")
+        if token.blank? || token.include?("/") || token.include?(":")
+          nil
+        else
+          token
+        end
       end
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -93,13 +93,114 @@ module CSP
     # and get tuned against violation reports during the report-only window.
     policy.img_src         :self, :data, :blob, *extra(:img_src)
     policy.connect_src     :self, *extra(:connect_src)
-    policy.frame_src       :self, *extra(:frame_src)
+    # frame-src is the render-time half of the iframe embed allowlist. It consumes
+    # EmbedAllowlist — the same source of truth HtmlScrubber uses at author-time —
+    # so a permitted-provider frame the scrubber keeps is one the browser will load,
+    # and the two enforcement points cannot drift. (Includes extra(:frame_src).)
+    policy.frame_src       :self, *::EmbedAllowlist.frame_src_sources
     policy.frame_ancestors :self
     policy.base_uri        :self
     policy.form_action     :self, *extra(:form_action)
     policy.object_src      :none
     # Specify URI for violation reports once a report sink is available
     # policy.report_uri "/csp-violation-report-endpoint"
+  end
+end
+
+# Single source of truth for which iframe embed providers Writebook permits.
+#
+# Consumed at two enforcement points that must never disagree:
+#   - author-time, by HtmlScrubber, which strips any <iframe> whose src host is
+#     not on this list before the page is stored/rendered; and
+#   - render-time, by the CSP frame-src directive below, which refuses to load a
+#     frame from an origin not on this list.
+# Both derive their host set from here, so an operator who adds a provider gets
+# it honored in both places from one change.
+#
+# Defined here (not app/models) because the CSP policy is built at boot, before
+# app autoloading can resolve an app/models constant; HtmlScrubber references it
+# at request time, by which point it is defined.
+#
+# ── PRODUCT DECISION ──────────────────────────────────────────────────────────
+# DEFAULT_PROVIDERS is the shipped default allowlist. Writebook is a ONCE product
+# (each customer self-hosts on their own domain), so the *mechanism* is per-
+# install configurable via the CSP_EXTRA_FRAME_SRC ENV — the same tokens CSP
+# frame-src reads. But the shipped default list below, the per-provider attribute
+# policy, and whether a raw-iframe escape hatch exists are product/authoring calls
+# an owner must confirm before this enforces. Set DEFAULT_PROVIDERS to {} to ship
+# with no built-in providers.
+module EmbedAllowlist
+  # Provider name => host matcher(s). A leading "*." matches the apex and any
+  # subdomain (e.g. "*.vimeo.com" matches "vimeo.com" and "player.vimeo.com").
+  # Product-owned default list — curate before enforcing.
+  DEFAULT_PROVIDERS = {
+    "YouTube"     => %w[ www.youtube.com youtube.com www.youtube-nocookie.com ],
+    "Vimeo"       => %w[ player.vimeo.com ],
+    "Loom"        => %w[ www.loom.com ],
+    "Google Maps" => %w[ www.google.com ]
+  }.freeze
+
+  ALLOWED_SCHEMES = %w[ https ].freeze
+
+  class << self
+    # Every host on the allowlist: the built-in defaults plus any hosts parsed
+    # out of the per-install CSP_EXTRA_FRAME_SRC ENV.
+    def hosts
+      (default_hosts + extra_hosts).uniq
+    end
+
+    # True when +src+ is an https URL whose host is on the allowlist.
+    def allows?(src)
+      uri = parse(src)
+      return false unless uri && ALLOWED_SCHEMES.include?(uri.scheme) && uri.host.present?
+
+      host = uri.host.downcase
+      hosts.any? { |pattern| host_matches?(host, pattern) }
+    end
+
+    # CSP frame-src source expressions for this same allowlist: the default
+    # provider origins as https:// URLs, plus the raw per-install extras (already
+    # CSP source expressions). Consumed by the CSP frame-src directive below so
+    # frame-src and the scrubber cannot drift.
+    def frame_src_sources
+      (default_hosts.map { |host| "https://#{host}" } + CSP.extra(:frame_src)).uniq
+    end
+
+    private
+      def default_hosts
+        DEFAULT_PROVIDERS.values.flatten
+      end
+
+      def extra_hosts
+        CSP.extra(:frame_src).filter_map { |source| host_from_source(source) }
+      end
+
+      def parse(src)
+        URI.parse(src.to_s.strip)
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def host_matches?(host, pattern)
+        pattern = pattern.downcase
+        if pattern.start_with?("*.")
+          apex = pattern.delete_prefix("*.")
+          host == apex || host.end_with?(".#{apex}")
+        else
+          host == pattern
+        end
+      end
+
+      # Extract a bare host from a CSP source expression: "https://www.youtube.com"
+      # or "https://*.vimeo.com/embed" => "www.youtube.com" / "*.vimeo.com". Returns
+      # nil for scheme-only or keyword tokens (:self, https:, 'unsafe-inline', a
+      # host:port) that carry no plain host to match an iframe src against.
+      def host_from_source(source)
+        token = source.to_s.strip.delete_prefix("https://").delete_prefix("http://")
+        token = token.split("/").first.to_s
+        return nil if token.blank? || token.include?(":") || token.start_with?("'")
+        token
+      end
   end
 end
 

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -24,10 +24,17 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_select "#test", html: %(<div style="text-align:center;">Hello</div>)
   end
 
-  test "show with iframes" do
+  test "show strips an off-allowlist iframe" do
     get leafable_path(sample_page_leaf(%(<div id="test"><iframe src="http://example.com"></iframe></div>)))
 
-    assert_select "#test", html: %(<iframe src="http://example.com"></iframe>)
+    assert_select "#test", html: %()
+    assert_select "iframe", false
+  end
+
+  test "show keeps an allowlisted-provider iframe" do
+    get leafable_path(sample_page_leaf(%(<div id="test"><iframe src="https://www.youtube.com/embed/abc"></iframe></div>)))
+
+    assert_select "#test iframe[src=?]", "https://www.youtube.com/embed/abc"
   end
 
   test "show with tables in the markdown" do

--- a/test/integration/csp_nonce_test.rb
+++ b/test/integration/csp_nonce_test.rb
@@ -79,11 +79,16 @@ class CspNonceTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "directives default to :self only when no ENV extras are set" do
+  test "directives default to :self plus the built-in embed providers when no ENV extras are set" do
     with_env "CSP_EXTRA_FRAME_SRC" => nil, "CSP_EXTRA_IMG_SRC" => nil do
       header = ActionDispatch::ContentSecurityPolicy.new { |p| CSP.apply(p) }.build
 
-      assert_match %r{frame-src 'self'(;|\z)}, header
+      # img-src has no built-in providers, so it stays at :self (+ data/blob).
+      assert_match %r{img-src 'self' data: blob:(;|\z)}, header
+      # frame-src consumes EmbedAllowlist: :self plus the shipped default provider
+      # origins, so the render-time policy agrees with the author-time scrubber.
+      assert_match %r{frame-src 'self'[^;]*\bhttps://www\.youtube\.com\b}, header
+      assert_match %r{frame-src 'self'[^;]*\bhttps://player\.vimeo\.com\b}, header
     end
   end
 

--- a/test/models/embed_allowlist_test.rb
+++ b/test/models/embed_allowlist_test.rb
@@ -27,6 +27,13 @@ class EmbedAllowlistTest < ActiveSupport::TestCase
     end
   end
 
+  test "non-default ports are rejected to match the portless CSP sources" do
+    with_env "CSP_EXTRA_FRAME_SRC" => nil do
+      assert_not EmbedAllowlist.allows?("https://www.youtube.com:8443/embed/x")
+      assert EmbedAllowlist.allows?("https://www.youtube.com:443/embed/x"), "an explicit default port matches like an omitted one"
+    end
+  end
+
   test "a per-install ENV host is honored, from the same source CSP frame-src reads" do
     with_env "CSP_EXTRA_FRAME_SRC" => "https://maps.example.test https://forms.example.test" do
       assert EmbedAllowlist.allows?("https://maps.example.test/embed")

--- a/test/models/embed_allowlist_test.rb
+++ b/test/models/embed_allowlist_test.rb
@@ -60,6 +60,12 @@ class EmbedAllowlistTest < ActiveSupport::TestCase
     end
   end
 
+  test "a bare trailing slash counts as the whole host, like the CSP root path does" do
+    with_env "CSP_EXTRA_FRAME_SRC" => "https://embed.example/" do
+      assert EmbedAllowlist.allows?("https://embed.example/widget")
+    end
+  end
+
   test "sources narrower than a plain origin feed CSP only, never the scrubber" do
     with_env "CSP_EXTRA_FRAME_SRC" => "https://example.test/approved/ https://ported.example.test:8443" do
       # Dropping the path or port would let the scrubber accept more than the

--- a/test/models/embed_allowlist_test.rb
+++ b/test/models/embed_allowlist_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class EmbedAllowlistTest < ActiveSupport::TestCase
+  test "default providers are allowed with no ENV set" do
+    with_env "CSP_EXTRA_FRAME_SRC" => nil do
+      assert EmbedAllowlist.allows?("https://www.youtube.com/embed/abc123")
+      assert EmbedAllowlist.allows?("https://player.vimeo.com/video/123")
+      assert EmbedAllowlist.allows?("https://www.loom.com/embed/xyz")
+    end
+  end
+
+  test "off-allowlist hosts are rejected" do
+    with_env "CSP_EXTRA_FRAME_SRC" => nil do
+      assert_not EmbedAllowlist.allows?("https://evil.example/embed")
+      assert_not EmbedAllowlist.allows?("https://notyoutube.com/embed")
+    end
+  end
+
+  test "non-https and non-absolute srcs are rejected" do
+    with_env "CSP_EXTRA_FRAME_SRC" => nil do
+      assert_not EmbedAllowlist.allows?("http://www.youtube.com/embed/x"), "http is rejected"
+      assert_not EmbedAllowlist.allows?("//www.youtube.com/embed/x"),      "protocol-relative is rejected"
+      assert_not EmbedAllowlist.allows?("/local/page"),                     "relative is rejected"
+      assert_not EmbedAllowlist.allows?("javascript:alert(1)"),            "javascript: is rejected"
+      assert_not EmbedAllowlist.allows?(nil)
+      assert_not EmbedAllowlist.allows?("")
+    end
+  end
+
+  test "a per-install ENV host is honored, from the same source CSP frame-src reads" do
+    with_env "CSP_EXTRA_FRAME_SRC" => "https://maps.example.test https://forms.example.test" do
+      assert EmbedAllowlist.allows?("https://maps.example.test/embed")
+      assert EmbedAllowlist.allows?("https://forms.example.test/f/1")
+      # and the same host appears in the CSP frame-src source list — no drift.
+      assert_includes EmbedAllowlist.frame_src_sources, "https://maps.example.test"
+    end
+  end
+
+  test "wildcard ENV hosts match the apex and any subdomain" do
+    with_env "CSP_EXTRA_FRAME_SRC" => "https://*.example.test" do
+      assert EmbedAllowlist.allows?("https://example.test/x")
+      assert EmbedAllowlist.allows?("https://deep.sub.example.test/x")
+      assert_not EmbedAllowlist.allows?("https://example.test.evil.com/x")
+    end
+  end
+
+  test "frame_src_sources always includes the default provider origins" do
+    with_env "CSP_EXTRA_FRAME_SRC" => nil do
+      assert_includes EmbedAllowlist.frame_src_sources, "https://www.youtube.com"
+      assert_includes EmbedAllowlist.frame_src_sources, "https://player.vimeo.com"
+    end
+  end
+
+  private
+    def with_env(vars)
+      original = {}
+      vars.each_key { |k| original[k] = ENV.key?(k) ? ENV[k] : :__unset__ }
+      vars.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+      yield
+    ensure
+      original.each { |k, v| v == :__unset__ ? ENV.delete(k) : ENV[k] = v }
+    end
+end

--- a/test/models/embed_allowlist_test.rb
+++ b/test/models/embed_allowlist_test.rb
@@ -53,6 +53,13 @@ class EmbedAllowlistTest < ActiveSupport::TestCase
     end
   end
 
+  test "an explicit :443 source counts as a plain https origin" do
+    with_env "CSP_EXTRA_FRAME_SRC" => "https://embed.example:443" do
+      assert EmbedAllowlist.allows?("https://embed.example/widget")
+      assert EmbedAllowlist.allows?("https://embed.example:443/widget")
+    end
+  end
+
   test "sources narrower than a plain origin feed CSP only, never the scrubber" do
     with_env "CSP_EXTRA_FRAME_SRC" => "https://example.test/approved/ https://ported.example.test:8443" do
       # Dropping the path or port would let the scrubber accept more than the

--- a/test/models/embed_allowlist_test.rb
+++ b/test/models/embed_allowlist_test.rb
@@ -38,9 +38,23 @@ class EmbedAllowlistTest < ActiveSupport::TestCase
 
   test "wildcard ENV hosts match the apex and any subdomain" do
     with_env "CSP_EXTRA_FRAME_SRC" => "https://*.example.test" do
-      assert EmbedAllowlist.allows?("https://example.test/x")
+      assert EmbedAllowlist.allows?("https://sub.example.test/x")
       assert EmbedAllowlist.allows?("https://deep.sub.example.test/x")
+      # CSP host-source semantics: *.example.test covers subdomains, not the apex.
+      assert_not EmbedAllowlist.allows?("https://example.test/x")
       assert_not EmbedAllowlist.allows?("https://example.test.evil.com/x")
+    end
+  end
+
+  test "sources narrower than a plain origin feed CSP only, never the scrubber" do
+    with_env "CSP_EXTRA_FRAME_SRC" => "https://example.test/approved/ https://ported.example.test:8443" do
+      # Dropping the path or port would let the scrubber accept more than the
+      # CSP source allows, so these admit no iframes at all.
+      assert_not EmbedAllowlist.allows?("https://example.test/approved/x")
+      assert_not EmbedAllowlist.allows?("https://example.test/unapproved")
+      assert_not EmbedAllowlist.allows?("https://ported.example.test/x")
+      # They still pass through to frame-src verbatim.
+      assert_includes EmbedAllowlist.frame_src_sources, "https://example.test/approved/"
     end
   end
 

--- a/test/models/html_scrubber_test.rb
+++ b/test/models/html_scrubber_test.rb
@@ -50,6 +50,16 @@ class HtmlScrubberTest < ActiveSupport::TestCase
     assert_not_includes out, "microphone"
   end
 
+  test "keeps an authored allowlist on a surviving allow directive" do
+    html = %(<iframe src="https://www.youtube.com/embed/x" allow="autoplay 'none'; clipboard-write https://other.example; camera *"></iframe>)
+    out  = scrub(html)
+
+    # Truncating `autoplay 'none'` to `autoplay` would grant what the author withheld.
+    assert_includes out, "autoplay 'none'"
+    assert_includes out, "clipboard-write https://other.example"
+    assert_not_includes out, "camera"
+  end
+
   test "honors a per-install ENV provider" do
     with_env "CSP_EXTRA_FRAME_SRC" => "https://maps.example.test" do
       out = scrub(%(<iframe src="https://maps.example.test/embed"></iframe>))

--- a/test/models/html_scrubber_test.rb
+++ b/test/models/html_scrubber_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class HtmlScrubberTest < ActiveSupport::TestCase
+  test "keeps an allowlisted-provider iframe" do
+    html = %(<p>hi</p><iframe src="https://www.youtube.com/embed/abc"></iframe>)
+    out  = scrub(html)
+
+    assert_includes out, "<iframe"
+    assert_includes out, %(src="https://www.youtube.com/embed/abc")
+  end
+
+  test "strips an off-allowlist iframe entirely" do
+    html = %(<p>before</p><iframe src="https://evil.example/x"></iframe><p>after</p>)
+    out  = scrub(html)
+
+    assert_not_includes out, "<iframe"
+    assert_not_includes out, "evil.example"
+    assert_includes out, "before"
+    assert_includes out, "after"
+  end
+
+  test "strips an iframe with no src" do
+    assert_not_includes scrub(%(<iframe srcdoc="<b>x</b>"></iframe>)), "<iframe"
+  end
+
+  test "minimizes attributes on a surviving iframe" do
+    html = <<~HTML
+      <iframe src="https://player.vimeo.com/video/1"
+              width="640" height="360" allowfullscreen
+              srcdoc="<script>alert(1)</script>"
+              onload="steal()" name="x" sandbox=""></iframe>
+    HTML
+    out = scrub(html)
+
+    assert_includes out, %(src="https://player.vimeo.com/video/1")
+    assert_includes out, "width", "vetted attributes survive"
+    assert_not_includes out, "srcdoc", "srcdoc is dropped"
+    assert_not_includes out, "onload", "on* handlers are dropped"
+    assert_not_includes out, "sandbox", "author sandbox override is dropped"
+    assert_not_includes out, %(name="x"), "arbitrary attributes are dropped"
+  end
+
+  test "filters the iframe allow attribute to a safe token set" do
+    html = %(<iframe src="https://www.youtube.com/embed/x" allow="fullscreen; camera; microphone; autoplay"></iframe>)
+    out  = scrub(html)
+
+    assert_match %r{allow="[^"]*fullscreen}, out
+    assert_match %r{allow="[^"]*autoplay}, out
+    assert_not_includes out, "camera"
+    assert_not_includes out, "microphone"
+  end
+
+  test "honors a per-install ENV provider" do
+    with_env "CSP_EXTRA_FRAME_SRC" => "https://maps.example.test" do
+      out = scrub(%(<iframe src="https://maps.example.test/embed"></iframe>))
+      assert_includes out, "maps.example.test"
+    end
+  end
+
+  private
+    def scrub(html)
+      Loofah.fragment(html).scrub!(HtmlScrubber.new).to_html
+    end
+
+    def with_env(vars)
+      original = {}
+      vars.each_key { |k| original[k] = ENV.key?(k) ? ENV[k] : :__unset__ }
+      vars.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+      yield
+    ensure
+      original.each { |k, v| v == :__unset__ ? ENV.delete(k) : ENV[k] = v }
+    end
+end

--- a/test/models/html_scrubber_test.rb
+++ b/test/models/html_scrubber_test.rb
@@ -36,7 +36,7 @@ class HtmlScrubberTest < ActiveSupport::TestCase
     assert_includes out, "width", "vetted attributes survive"
     assert_not_includes out, "srcdoc", "srcdoc is dropped"
     assert_not_includes out, "onload", "on* handlers are dropped"
-    assert_not_includes out, "sandbox", "author sandbox override is dropped"
+    assert_includes out, %(sandbox=""), "an authored sandbox only restricts and survives"
     assert_not_includes out, %(name="x"), "arbitrary attributes are dropped"
   end
 
@@ -48,6 +48,20 @@ class HtmlScrubberTest < ActiveSupport::TestCase
     assert_match %r{allow="[^"]*autoplay}, out
     assert_not_includes out, "camera"
     assert_not_includes out, "microphone"
+  end
+
+  test "keeps an authored sandbox and drops a leaking referrerpolicy" do
+    html = %(<iframe src="https://www.youtube.com/embed/x" sandbox="" referrerpolicy="unsafe-url"></iframe>)
+    out  = scrub(html)
+
+    assert_includes out, "sandbox", "an authored sandbox only ever restricts; stripping it would grant privileges"
+    assert_not_includes out, "referrerpolicy", "unsafe-url leaks the reader's full URL to the provider"
+  end
+
+  test "keeps a non-leaking referrerpolicy" do
+    out = scrub(%(<iframe src="https://www.youtube.com/embed/x" referrerpolicy="no-referrer"></iframe>))
+
+    assert_includes out, %(referrerpolicy="no-referrer")
   end
 
   test "keeps an authored allowlist on a surviving allow directive" do


### PR DESCRIPTION
Closes the `DG4` residue: `HtmlScrubber` allowed `<iframe src>` from **any** origin in authored markdown, rendered to unauthenticated book readers.

Introduces `EmbedAllowlist` as the single source of truth for permitted embed hosts, **enforced twice**:
- **Display-time** (`HtmlScrubber`): every content render path passes through `sanitize_content`, which keeps an `<iframe>` only when its `src` host is on the allowlist and minimizes a survivor to a vetted attribute set (drop `srcdoc`, `on*`, `name`, `sandbox` overrides; filter `allow` to a safe feature set, preserving each permitted directive's authored allowlist syntax). Stored Markdown stays raw, so the list applies retroactively to existing content.
- **Browser-side** (CSP `frame-src`): consumes the same `EmbedAllowlist`, so a provider the scrubber keeps is one the browser will load — the two enforcement points **cannot drift**. Scrubber matching mirrors CSP source semantics: `*.host` covers subdomains only (never the apex), and a source narrower than a plain https origin (path, port) feeds `frame-src` verbatim while admitting no iframes.

The host set is per-install configurable via the same `CSP_EXTRA_FRAME_SRC` ENV the CSP branch tokenizes (Writebook is a self-hosted ONCE product), plus a shipped default provider list.

⚠️ **PRODUCT DECISION** (flagged in `EmbedAllowlist`): the default provider list, per-provider attribute policy, grandfathering of existing off-allowlist embeds, and any raw-iframe escape hatch are product/authoring calls an owner must confirm before this enforces.

**Stacked on** `security/xss-campaign-writebook-csp-report-only`. Tests green (embed allowlist, scrubber, CSP, pages controller). Draft spike for the XSS counteroffensive Tier C.