### PR TITLE
Keep the sidebar within the viewport

### DIFF
--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -93,15 +93,19 @@ body {
   }
 }
 
+/* The sidebar spans all four grid rows, so sizing it against its grid area makes
+   it as tall as the whole document and its overflow never kicks in. Stick it to
+   the viewport instead, so the table of contents scrolls its own content. */
 :where(#sidebar) {
   background-color: var(--color-subtle-light);
-  block-size: 100%;
+  block-size: 100dvh;
   font-size: var(--font-medium-responsive);
   grid-area: sidebar;
   inline-size: 25vw;
-  max-block-size: 100%;
+  inset-block-start: 0;
+  max-block-size: 100dvh;
   overflow: auto;
-  position: relative;
+  position: sticky;
   transition: margin-inline-start 0.2s ease-out;
 
   :has(#sidebar-toggle:checked) & {

--- a/test/system/sidebar_scroll_test.rb
+++ b/test/system/sidebar_scroll_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class SidebarScrollTest < ApplicationSystemTestCase
+  setup do
+    sign_in "kevin@example.com"
+
+    leaves(:welcome_page).leafable.update! body: ([ "A paragraph of the book." ] * 400).join("\n\n")
+
+    visit leafable_slug_path(leaves(:welcome_page))
+    find("label.sidebar__toggle").click
+
+    assert_operator document_height, :>, viewport_height * 2,
+      "the test page should be considerably taller than the viewport"
+  end
+
+  test "the table of contents fits the viewport instead of the page" do
+    assert_operator sidebar_height, :<=, viewport_height,
+      "the sidebar is #{sidebar_height}px tall in a #{viewport_height}px viewport: " \
+      "it grows with the length of the page instead of staying within the screen"
+  end
+
+  test "the table of contents stays put while the page scrolls" do
+    execute_script "window.scrollTo(0, document.documentElement.scrollHeight)"
+
+    assert_equal 0, sidebar_top.round,
+      "the sidebar scrolled away with the page instead of staying in view"
+  end
+
+  private
+    def viewport_height = evaluate_script("window.innerHeight")
+
+    def document_height = evaluate_script("document.documentElement.scrollHeight")
+
+    def sidebar_height = sidebar_rect["height"]
+
+    def sidebar_top = sidebar_rect["top"]
+
+    def sidebar_rect
+      evaluate_script("document.querySelector('#sidebar').getBoundingClientRect().toJSON()")
+    end
+end


### PR DESCRIPTION
Fixes #475.

## The problem

`#sidebar` is a grid item spanning all four rows of the `body` grid, so `block-size: 100%` and `max-block-size: 100%` resolve against a grid area as tall as the whole document. The element is never shorter than its content, so its `overflow: auto` never engages, and the absolutely positioned `.toc.sidebar__content` inside it (`inset: 0 auto 0 0`) stretches to the bottom of the page along with it.

In a book with long pages that leaves the page scrollbar as the only way to reach the end of the table of contents, and scrolling the text drags the navigation out of view. On a 1257px viewport with a long page the sidebar measures just over 20,000px tall.

## The fix

Stick the sidebar to the viewport and bound it to `100dvh`, so it scrolls its own content:

```css
block-size: 100dvh;      /* was 100%     */
max-block-size: 100dvh;  /* was 100%     */
inset-block-start: 0;    /* new          */
position: sticky;        /* was relative */
```

`sticky` rather than `fixed` keeps the sidebar a grid item, so the column keeps its width and the open/close `margin-inline-start` transition is untouched. It also still establishes the containing block for the absolutely positioned menu inside it.

`dvh` needs a 2022-or-newer browser, which is no newer than the `:has()` and container queries already in use. The sidebar is `display: none` below `70ch`, so the mobile layout is unaffected.

## Tests

`test/system/sidebar_scroll_test.rb` covers both halves of the problem, and both fail without the change:

- the sidebar fits the viewport instead of growing with the page — before the fix it measures `20970.64px` in a `1257px` viewport
- it stays at `top: 0` after the page is scrolled to the bottom

Full suite is green on Ruby 3.4.7.
