### PR TITLE
Fix RegexpError 500 in search highlighting when a term contains regex metacharacters

### DIFF
--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -22,7 +22,10 @@ module SearchesHelper
   end
 
   private
+    # Terms come from FTS5 highlight() spans, which can include document
+    # punctuation (e.g. a phrase match spanning "foo) bar"). Escape them so
+    # metacharacters are matched literally instead of raising a RegexpError.
     def whole_word_matchers(terms)
-      terms.map { |term| /\b#{term}\b/ }
+      terms.map { |term| /\b#{Regexp.escape(term)}\b/ }
     end
 end

--- a/test/controllers/leafables_controller_test.rb
+++ b/test/controllers/leafables_controller_test.rb
@@ -30,6 +30,20 @@ class LeafablesControllerTest < ActionDispatch::IntegrationTest
     assert_select "mark", "great"
   end
 
+  test "show highlights a phrase match whose span contains regex metacharacters" do
+    sign_out
+    books(:handbook).update!(published: true)
+
+    section = Section.new(body: "alpha) omega in the body")
+    books(:handbook).press(section, title: "Punctuated")
+    section.leaf.reindex
+
+    get leafable_slug_path(section.leaf), params: { search: '"alpha omega"' }
+
+    assert_response :success
+    assert_select "mark", text: /alpha\) omega/
+  end
+
   test "show does not allow public access to an unpublished book" do
     sign_out
 

--- a/test/helpers/searches_helper_test.rb
+++ b/test/helpers/searches_helper_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class SearchesHelperTest < ActionView::TestCase
+  include PagesHelper
   test "sanitize_search_result preserves mark tags" do
     assert_equal "<mark>findme</mark> text", sanitize_search_result("<mark>findme</mark> text")
   end
@@ -15,5 +16,15 @@ class SearchesHelperTest < ActionView::TestCase
 
   test "sanitize_search_result strips attributes from mark tags" do
     assert_equal "<mark>findme</mark> text", sanitize_search_result('<mark class="hidden">findme</mark> text')
+  end
+
+  test "highlight_searched_content handles matched terms containing regex metacharacters" do
+    leaf = Struct.new(:terms) do
+      def matches_for_highlight(_query) = terms
+    end.new([ "foo) bar" ])
+
+    result = highlight_searched_content(leaf, "foo) bar in the body", "foo bar")
+
+    assert_includes result, "<mark>foo) bar</mark>"
   end
 end


### PR DESCRIPTION
## Problem

`SearchesHelper#whole_word_matchers` interpolates a matched term straight into `/\b#{term}\b/` without escaping it:

```ruby
def whole_word_matchers(terms)
  terms.map { |term| /\b#{term}\b/ }
end
```

These terms are not the raw search query — they are spans pulled from SQLite FTS5's `highlight()` output, which can include document punctuation. A phrase match spanning something like `foo) bar` produces a term with an unbalanced parenthesis, so the `Regexp` constructor raises `RegexpError` and the leaf page 500s instead of rendering the highlighted result.

Reproduction: a book body containing `alpha) omega`, then viewing that page with `?search="alpha omega"` (a phrase query) raises `RegexpError: unmatched close parenthesis: /\balpha) omega\b/`.

## Fix

Escape the term with `Regexp.escape` before interpolation so metacharacters are matched literally:

```ruby
terms.map { |term| /\b#{Regexp.escape(term)}\b/ }
```

The whole-word `\b` boundaries and the rest of the highlighting behavior are unchanged; the escaped term still highlights correctly.

## Tests

- Helper test: `highlight_searched_content` handles a matched term containing regex metacharacters.
- Controller test: viewing a published book's page with a phrase search whose highlight span contains metacharacters returns success and highlights the span.

Both fail with `RegexpError` before the change and pass after.