### PR TITLE
Handle empty and FTS5-operator search queries without raising a 500

### DIFF
--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -22,7 +22,10 @@ module SearchesHelper
   end
 
   private
+    # Terms come from FTS5 highlight() spans, which can include document
+    # punctuation (e.g. a phrase match spanning "alpha(beta"). Escape them so
+    # metacharacters are matched literally instead of raising a RegexpError.
     def whole_word_matchers(terms)
-      terms.map { |term| /\b#{term}\b/ }
+      terms.map { |term| /\b#{Regexp.escape(term)}\b/ }
     end
 end

--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -22,9 +22,6 @@ module SearchesHelper
   end
 
   private
-    # Terms come from FTS5 highlight() spans, which can include document
-    # punctuation (e.g. a phrase match spanning "alpha(beta"). Escape them so
-    # metacharacters are matched literally instead of raising a RegexpError.
     def whole_word_matchers(terms)
       terms.map { |term| /\b#{Regexp.escape(term)}\b/ }
     end

--- a/app/models/leaf/searchable.rb
+++ b/app/models/leaf/searchable.rb
@@ -17,7 +17,7 @@ module Leaf::Searchable
     def sanitize_query_syntax(terms)
       terms = terms.to_s
       terms = remove_invalid_search_characters(terms)
-      terms = remove_unbalanced_quotes(terms)
+      terms = quote_query_tokens(terms)
       terms.presence
     end
 
@@ -50,6 +50,8 @@ module Leaf::Searchable
         .pick(Arel.sql("highlight(leaf_search_index, 1, '<mark>', '</mark>')"))
 
       content ? unique_matching_terms(content) : []
+    else
+      []
     end
   end
 
@@ -106,12 +108,16 @@ module Leaf::Searchable
           terms.gsub(/[^\w"]/, " ")
         end
 
-        def remove_unbalanced_quotes(terms)
-          if terms.count("\"").even?
-            terms
-          else
-            terms.gsub("\"", " ")
-          end
+        # After stripping the characters FTS5 can't tokenize, the remaining
+        # input may still be an FTS5 boolean operator (AND/OR/NOT/NEAR) or
+        # carry an unbalanced double quote — either of which makes SQLite raise
+        # a syntax error. Rebuild the query from its balanced "quoted phrases"
+        # and bare words, wrapping every token as a quoted string literal so
+        # arbitrary input is matched literally instead of parsed as syntax.
+        def quote_query_tokens(terms)
+          terms.scan(/"[^"]+"|\w+/)
+            .map { |token| %("#{token.delete('"')}") }
+            .join(" ")
         end
     end
 end

--- a/app/models/leaf/searchable.rb
+++ b/app/models/leaf/searchable.rb
@@ -15,10 +15,6 @@ module Leaf::Searchable
     end
 
     def sanitize_query_syntax(terms)
-      # scrub replaces any invalid UTF-8 bytes so the gsub below can't raise an
-      # ArgumentError on a malformed string. Reachable over HTTP only in theory
-      # — Rails rejects malformed query/body encoding with a 400 first — but it
-      # keeps this shared sink total for every caller.
       terms = terms.to_s.scrub
       terms = remove_invalid_search_characters(terms)
       terms = quote_query_tokens(terms)

--- a/app/models/leaf/searchable.rb
+++ b/app/models/leaf/searchable.rb
@@ -114,9 +114,15 @@ module Leaf::Searchable
         # a syntax error. Rebuild the query from its balanced "quoted phrases"
         # and bare words, wrapping every token as a quoted string literal so
         # arbitrary input is matched literally instead of parsed as syntax.
+        #
+        # Match empty quote pairs too (`[^"]*`, not `+`) so a stray `""` is
+        # consumed in place rather than pairing its closing quote with the next
+        # opening one — which would shift the boundaries of a following phrase
+        # and split it into separate word matches. Empty tokens are then dropped.
         def quote_query_tokens(terms)
-          terms.scan(/"[^"]+"|\w+/)
-            .map { |token| %("#{token.delete('"')}") }
+          terms.scan(/"[^"]*"|\w+/)
+            .filter_map { |token| token.delete('"').presence }
+            .map { |token| %("#{token}") }
             .join(" ")
         end
     end

--- a/app/models/leaf/searchable.rb
+++ b/app/models/leaf/searchable.rb
@@ -15,7 +15,11 @@ module Leaf::Searchable
     end
 
     def sanitize_query_syntax(terms)
-      terms = terms.to_s
+      # scrub replaces any invalid UTF-8 bytes so the gsub below can't raise an
+      # ArgumentError on a malformed string. Reachable over HTTP only in theory
+      # — Rails rejects malformed query/body encoding with a 400 first — but it
+      # keeps this shared sink total for every caller.
+      terms = terms.to_s.scrub
       terms = remove_invalid_search_characters(terms)
       terms = quote_query_tokens(terms)
       terms.presence

--- a/test/controllers/books/searches_controller_test.rb
+++ b/test/controllers/books/searches_controller_test.rb
@@ -43,14 +43,14 @@ class Books::SearchesControllerTest < ActionDispatch::IntegrationTest
 
   test "create shows no matches when the search uses FTS5 operator syntax" do
     [ "OR", "AND", "NOT", "great OR", "NEAR handbook", "great AND NOT" ].each do |query|
-      post book_search_url(books(:handbook)), params: { search: query }
+      post book_search_path(books(:handbook)), params: { search: query }
 
       assert_response :success, "expected #{query.inspect} to render without error"
     end
   end
 
   test "create still finds matches for an ordinary multi-word query" do
-    post book_search_url(books(:handbook)), params: { search: "great handbook" }
+    post book_search_path(books(:handbook)), params: { search: "great handbook" }
 
     assert_response :success
     assert_select "a.search__result"

--- a/test/controllers/books/searches_controller_test.rb
+++ b/test/controllers/books/searches_controller_test.rb
@@ -41,6 +41,21 @@ class Books::SearchesControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: /no matches/i
   end
 
+  test "create shows no matches when the search uses FTS5 operator syntax" do
+    [ "OR", "AND", "NOT", "great OR", "NEAR handbook", "great AND NOT" ].each do |query|
+      post book_search_url(books(:handbook)), params: { search: query }
+
+      assert_response :success, "expected #{query.inspect} to render without error"
+    end
+  end
+
+  test "create still finds matches for an ordinary multi-word query" do
+    post book_search_url(books(:handbook)), params: { search: "great handbook" }
+
+    assert_response :success
+    assert_select "a.search__result"
+  end
+
   test "create does not find trashed pages" do
     leaves(:summary_page).trashed!
 

--- a/test/controllers/leafables_controller_test.rb
+++ b/test/controllers/leafables_controller_test.rb
@@ -55,6 +55,20 @@ class LeafablesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "show does not raise when a phrase match spans regex metacharacters" do
+    sign_out
+    books(:handbook).update!(published: true)
+
+    section = Section.new(body: "alpha(beta gamma in the body")
+    books(:handbook).press(section, title: "Punctuated")
+    section.leaf.reindex
+
+    get leafable_slug_path(section.leaf), params: { search: "alpha_beta" }
+
+    assert_response :success
+    assert_select "mark", text: /alpha\(beta/
+  end
+
   test "show does not allow public access to an unpublished book" do
     sign_out
 

--- a/test/controllers/leafables_controller_test.rb
+++ b/test/controllers/leafables_controller_test.rb
@@ -30,6 +30,31 @@ class LeafablesControllerTest < ActionDispatch::IntegrationTest
     assert_select "mark", "great"
   end
 
+  test "show does not raise when the search query sanitizes to empty" do
+    sign_out
+    books(:handbook).update!(published: true)
+    Leaf.reindex_all
+
+    [ "^$", "!!!", "🙂", "\"" ].each do |query|
+      get leafable_slug_path(leaves(:welcome_page)), params: { search: query }
+
+      assert_response :success, "expected #{query.inspect} to render without error"
+      assert_select "p", "This is such a great handbook."
+    end
+  end
+
+  test "show does not raise when the search query uses FTS5 operator syntax" do
+    sign_out
+    books(:handbook).update!(published: true)
+    Leaf.reindex_all
+
+    [ "OR", "AND", "NOT", "great OR", "NEAR handbook", "great AND NOT" ].each do |query|
+      get leafable_slug_path(leaves(:welcome_page)), params: { search: query }
+
+      assert_response :success, "expected #{query.inspect} to render without error"
+    end
+  end
+
   test "show does not allow public access to an unpublished book" do
     sign_out
 

--- a/test/controllers/leafables_controller_test.rb
+++ b/test/controllers/leafables_controller_test.rb
@@ -39,7 +39,7 @@ class LeafablesControllerTest < ActionDispatch::IntegrationTest
       get leafable_slug_path(leaves(:welcome_page)), params: { search: query }
 
       assert_response :success, "expected #{query.inspect} to render without error"
-      assert_select "p", "This is such a great handbook."
+      assert_in_body "a great handbook."
     end
   end
 
@@ -59,11 +59,10 @@ class LeafablesControllerTest < ActionDispatch::IntegrationTest
     sign_out
     books(:handbook).update!(published: true)
 
-    section = Section.new(body: "alpha(beta gamma in the body")
-    books(:handbook).press(section, title: "Punctuated")
-    section.leaf.reindex
+    sections(:welcome).update!(body: "alpha(beta gamma in the body")
+    leaves(:welcome_section).reindex
 
-    get leafable_slug_path(section.leaf), params: { search: "alpha_beta" }
+    get leafable_slug_path(leaves(:welcome_section)), params: { search: "alpha_beta" }
 
     assert_response :success
     assert_select "mark", text: /alpha\(beta/

--- a/test/helpers/searches_helper_test.rb
+++ b/test/helpers/searches_helper_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class SearchesHelperTest < ActionView::TestCase
+  include PagesHelper
+
   test "sanitize_search_result preserves mark tags" do
     assert_equal "<mark>findme</mark> text", sanitize_search_result("<mark>findme</mark> text")
   end
@@ -15,5 +17,15 @@ class SearchesHelperTest < ActionView::TestCase
 
   test "sanitize_search_result strips attributes from mark tags" do
     assert_equal "<mark>findme</mark> text", sanitize_search_result('<mark class="hidden">findme</mark> text')
+  end
+
+  test "highlight_searched_content handles matched terms containing regex metacharacters" do
+    leaf = Struct.new(:terms) do
+      def matches_for_highlight(_query) = terms
+    end.new([ "alpha(beta" ])
+
+    result = highlight_searched_content(leaf, "alpha(beta in the body", "alpha beta")
+
+    assert_includes result, "<mark>alpha(beta</mark>"
   end
 end

--- a/test/models/leaf/searchable_test.rb
+++ b/test/models/leaf/searchable_test.rb
@@ -56,6 +56,19 @@ class Leaf::SearchableTest < ActiveSupport::TestCase
     assert_includes Leaf.search("\"great handbook\""), leaves(:welcome_page)
   end
 
+  test "a stray empty quote pair does not split a following phrase" do
+    # "" must be consumed in place; otherwise the phrase "great handbook"
+    # degrades into separate word matches that also hit documents where the
+    # two words are present but non-adjacent.
+    sections(:welcome).update!(body: "great old handbook")
+    leaves(:welcome_section).reindex
+
+    results = Leaf.search("\"\" \"great handbook\"")
+
+    assert_includes results, leaves(:welcome_page)
+    assert_not_includes results, leaves(:welcome_section)
+  end
+
   test "indexing sanitizes section body" do
     section = Section.new(body: 'findme Tom & Jerry <img src=x onerror="alert(1)">')
     books(:handbook).press(section, title: "Safe Title")

--- a/test/models/leaf/searchable_test.rb
+++ b/test/models/leaf/searchable_test.rb
@@ -69,6 +69,16 @@ class Leaf::SearchableTest < ActiveSupport::TestCase
     assert_not_includes results, leaves(:welcome_section)
   end
 
+  test "search does not raise on invalid UTF-8 byte sequences" do
+    malformed = "caf\xFF".dup.force_encoding("UTF-8")
+    assert_not malformed.valid_encoding?
+
+    assert_nothing_raised do
+      assert_empty Leaf.search(malformed)
+      assert_empty leaves(:welcome_page).matches_for_highlight(malformed)
+    end
+  end
+
   test "indexing sanitizes section body" do
     section = Section.new(body: 'findme Tom & Jerry <img src=x onerror="alert(1)">')
     books(:handbook).press(section, title: "Safe Title")

--- a/test/models/leaf/searchable_test.rb
+++ b/test/models/leaf/searchable_test.rb
@@ -38,6 +38,24 @@ class Leaf::SearchableTest < ActiveSupport::TestCase
     assert_empty markup
   end
 
+  test "matches_for_highlight is empty when the query sanitizes to nothing" do
+    assert_empty leaves(:welcome_page).matches_for_highlight("^$")
+    assert_empty leaves(:welcome_page).matches_for_highlight("🙂")
+    assert_empty leaves(:welcome_page).matches_for_highlight("\"")
+  end
+
+  test "search treats FTS5 operators as literal terms rather than syntax" do
+    # Operator tokens are searched literally, so they match only if the document
+    # actually contains that word — never raising an FTS5 syntax error.
+    assert_empty Leaf.search("OR")
+    assert_empty Leaf.search("great AND NOT")
+    assert_empty Leaf.search("great OR handbook")
+
+    # A legitimate multi-term query keeps working after the escaping change.
+    assert_includes Leaf.search("great handbook"), leaves(:welcome_page)
+    assert_includes Leaf.search("\"great handbook\""), leaves(:welcome_page)
+  end
+
   test "indexing sanitizes section body" do
     section = Section.new(body: 'findme Tom & Jerry <img src=x onerror="alert(1)">')
     books(:handbook).press(section, title: "Safe Title")

--- a/test/models/leaf/searchable_test.rb
+++ b/test/models/leaf/searchable_test.rb
@@ -45,21 +45,15 @@ class Leaf::SearchableTest < ActiveSupport::TestCase
   end
 
   test "search treats FTS5 operators as literal terms rather than syntax" do
-    # Operator tokens are searched literally, so they match only if the document
-    # actually contains that word — never raising an FTS5 syntax error.
     assert_empty Leaf.search("OR")
     assert_empty Leaf.search("great AND NOT")
     assert_empty Leaf.search("great OR handbook")
 
-    # A legitimate multi-term query keeps working after the escaping change.
     assert_includes Leaf.search("great handbook"), leaves(:welcome_page)
     assert_includes Leaf.search("\"great handbook\""), leaves(:welcome_page)
   end
 
   test "a stray empty quote pair does not split a following phrase" do
-    # "" must be consumed in place; otherwise the phrase "great handbook"
-    # degrades into separate word matches that also hit documents where the
-    # two words are present but non-adjacent.
     sections(:welcome).update!(body: "great old handbook")
     leaves(:welcome_section).reindex
 


### PR DESCRIPTION
Three ways a weird query on the book search path could raise an unhandled exception and break the page render. All are reachable through the `?search=` parameter (the search dialog and the highlighted leaf views: `Books::SearchesController#create` and `LeafablesController#show`).

### 1. Query sanitizes to empty → `nil.map`

A query made entirely of characters we strip (`^$`, an emoji, `!!!`, a bare `"`) sanitizes down to nothing. `matches_for_highlight` then returned `nil`, and the highlight helper called `nil.map`. Now it returns `[]`, which renders as normal un-highlighted content — matching the "no matches" behaviour the results view already has.

### 2. FTS5 boolean operators → SQLite syntax error

Bare FTS5 operators (`OR`, `AND`, `NOT`, `NEAR`, …) are word characters, so they survived character sanitization and reached SQLite as a raw FTS5 query, raising `fts5: syntax error near "OR"`. `quote_query_tokens` now rebuilds the sanitized query from its balanced quoted phrases and bare words, quoting every token as a string literal so arbitrary input is matched literally. This also subsumes the previous unbalanced-quote handling (a stray `"` is simply never captured as a token).

### 3. Punctuated phrase match → `RegexpError` in the highlighter

FTS5 `highlight()` spans can include document punctuation, so a phrase match against content like `alpha(beta` hands the highlight helper a term containing regex metacharacters. Interpolating it straight into `/\b...\b/` raised a `RegexpError` (e.g. `?search=alpha_beta` on a page containing `alpha(beta`). The term is now `Regexp.escape`d.

Ordinary term and phrase searches are unaffected — `great handbook` and `"great handbook"` still match as before. Boolean-operator queries now match their operators literally rather than as syntax; this is a deliberate tradeoff for a free-text search box that never documented Boolean support.

### Tests

- Model: `matches_for_highlight` is empty for empty-sanitizing queries; `search` treats operators literally without raising and keeps normal/phrase matches working.
- Controllers: `leafables#show` and book search render `:success` for empty-sanitizing, operator, and punctuation-spanning queries; ordinary multi-word search still returns results.
- Helper: highlighting a term containing regex metacharacters no longer raises.

Full suite green; rubocop and brakeman clean.