### PR TITLE
Keep .claude out of the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -53,3 +53,6 @@
 
 # Ignore test files
 /test/
+
+# Agent session state — worktrees under .claude/ are whole extra checkouts of this repo
+.claude

--- a/.dockerignore
+++ b/.dockerignore
@@ -54,5 +54,8 @@
 # Ignore test files
 /test/
 
-# Agent session state — worktrees under .claude/ are whole extra checkouts of this repo
-.claude
+# Agent session state — worktrees under .claude/worktrees/ are whole extra checkouts of this
+# repo, and other .claude entries are local session files. The tracked .claude/CLAUDE.md must
+# survive: Dockerfile-export packages this context into the writebook.zip customers download.
+/.claude/*
+!/.claude/CLAUDE.md


### PR DESCRIPTION
Local agent session state (`.claude`) can grow large — worktrees under `.claude/worktrees` are whole extra checkouts of the repo — and ships with the Docker build context, bloating images. Ignore it.