### PR TITLE
Restrict Markdown HTML sanitizer to an explicit attribute allowlist

### DIFF
--- a/app/models/html_scrubber.rb
+++ b/app/models/html_scrubber.rb
@@ -1,8 +1,52 @@
 class HtmlScrubber < Rails::Html::PermitScrubber
+  # MarkdownRenderer wires generated image anchors to the lightbox with exactly this
+  # action. It's the only data-action value allowed to survive, so authored HTML
+  # can't bind arbitrary (including auto-firing) Stimulus/Turbo actions to the page's
+  # controllers. The value is inert on its own: it opens the lightbox on click,
+  # reading the anchor's already-scrubbed href.
+  LIGHTBOX_ACTION = "lightbox#open:prevent".freeze
+
+  # Attributes the extra media/embed tags need that aren't in Loofah's safe set.
+  # Deliberately excludes value-sensitive iframe attributes (allow, referrerpolicy,
+  # sandbox) that can delegate capabilities or leak referrers.
+  MEDIA_ATTRIBUTES = %w[
+    controls autoplay muted playsinline allowfullscreen frameborder loading open reversed
+  ].freeze
+
   def initialize
     super
     self.tags = Rails::Html::WhiteListSanitizer.allowed_tags + %w[
       audio details summary iframe options table tbody td th thead tr video source mark
     ]
+    # Base on Loofah's vetted safe-attribute set rather than an unset list. An unset
+    # list falls back to Loofah's default scrub, whose data-* wildcard lets stored
+    # content carry a self-firing Stimulus/Turbo gadget (data-controller,
+    # data-turbo-*). The explicit set omits that wildcard; on* handlers and srcdoc
+    # are dropped, and URL/CSS values are still scrubbed.
+    self.attributes = Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.to_a \
+      + MEDIA_ATTRIBUTES + %w[ data-action ]
   end
+
+  def scrub(node)
+    super.tap do
+      remove_foreign_actions(node) if node.element?
+    end
+  end
+
+  # ARIA is a non-scriptable namespace Loofah allows by wildcard; keep it.
+  def scrub_attribute?(name)
+    return false if name.start_with?("aria-") || name == "role"
+    super
+  end
+
+  private
+    # The renderer emits the lightbox action only on <a>, where Stimulus's default
+    # event is click. Restricting to <a> keeps the eventless action from binding to
+    # a default-event element that fires without interaction (e.g. <details> toggle).
+    def remove_foreign_actions(node)
+      node.attribute_nodes.each do |attr|
+        next unless attr.name == "data-action"
+        attr.remove unless node.name == "a" && attr.value == LIGHTBOX_ACTION
+      end
+    end
 end

--- a/test/models/html_scrubber_test.rb
+++ b/test/models/html_scrubber_test.rb
@@ -57,14 +57,17 @@ class HtmlScrubberTest < ActiveSupport::TestCase
     kept = scrub(%(<a data-action="lightbox#open:prevent" href="/x">ok</a>))
     assert_includes kept, %(data-action="lightbox#open:prevent")
 
-    # Foreign actions are stripped outright.
+    # Foreign actions are stripped outright — including on an <a>, so it's the exact
+    # value, not merely the anchor tag, that gates survival.
     %w[
       turbo:load@window->lightbox#open
       load->arrangement#dragStartCreate
       mouseover->scroll-to-highlight#scroll
     ].each do |action|
-      result = scrub(%(<div data-action="#{action}">x</div>))
-      assert_not_includes result, "data-action", "expected #{action.inspect} to be stripped"
+      %w[div a].each do |tag|
+        result = scrub(%(<#{tag} data-action="#{action}" href="/x">x</#{tag}>))
+        assert_not_includes result, "data-action", "expected #{action.inspect} on <#{tag}> to be stripped"
+      end
     end
 
     # Even the benign action is stripped off a default-event element that would

--- a/test/models/html_scrubber_test.rb
+++ b/test/models/html_scrubber_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+class HtmlScrubberTest < ActiveSupport::TestCase
+  def scrub(html)
+    ApplicationController.helpers.sanitize(html, scrubber: HtmlScrubber.new)
+  end
+
+  def render_and_scrub(markdown)
+    scrub(ActionText::Markdown.renderer.call.render(markdown))
+  end
+
+  test "strips inline event handlers on allowed tags" do
+    %w[iframe img video audio details].each do |tag|
+      result = scrub(%(<#{tag} onload="alert(1)" onerror="alert(1)"></#{tag}>))
+      assert_not_includes result, "onload"
+      assert_not_includes result, "onerror"
+      assert_not_includes result, "alert(1)"
+    end
+  end
+
+  test "strips iframe srcdoc so framed markup cannot run script" do
+    result = scrub(%(<iframe srcdoc="<script>alert(1)</script>"></iframe>))
+    assert_not_includes result, "srcdoc"
+    assert_not_includes result, "alert(1)"
+  end
+
+  test "strips data-controller and data-turbo gadget attributes" do
+    result = scrub(%(<div data-controller="edit-mode" data-turbo-method="delete" data-turbo-stream="x" data-foo="y">hi</div>))
+    assert_not_includes result, "data-controller"
+    assert_not_includes result, "data-turbo"
+    assert_not_includes result, "data-foo"
+    assert_includes result, "hi"
+  end
+
+  test "strips javascript: URL schemes from href and src" do
+    assert_not_includes scrub(%(<a href="javascript:alert(1)">x</a>)), "javascript"
+    assert_not_includes scrub(%(<iframe src="javascript:alert(1)"></iframe>)), "javascript"
+  end
+
+  test "scrubs javascript from style attributes to block CSS injection" do
+    result = scrub(%(<p style="background:url(javascript:alert(1))">x</p>))
+    assert_not_includes result, "javascript"
+    assert_not_includes result, "alert(1)"
+  end
+
+  test "preserves the Markdown renderer's lightbox image wiring" do
+    result = render_and_scrub("![cat](/uploads/cat.png)")
+    assert_includes result, %(data-action="lightbox#open:prevent")
+    assert_includes result, %(href="/uploads/cat.png")
+    assert_includes result, %(<img src="/uploads/cat.png" alt="cat">)
+  end
+
+  test "allows the lightbox action only on anchors, not arbitrary data-action" do
+    # The lightbox action survives only on <a> (where Stimulus's default event is
+    # click); it is inert there — opens the image dialog on click, reading the
+    # scrubbed href.
+    kept = scrub(%(<a data-action="lightbox#open:prevent" href="/x">ok</a>))
+    assert_includes kept, %(data-action="lightbox#open:prevent")
+
+    # Foreign actions are stripped outright.
+    %w[
+      turbo:load@window->lightbox#open
+      load->arrangement#dragStartCreate
+      mouseover->scroll-to-highlight#scroll
+    ].each do |action|
+      result = scrub(%(<div data-action="#{action}">x</div>))
+      assert_not_includes result, "data-action", "expected #{action.inspect} to be stripped"
+    end
+
+    # Even the benign action is stripped off a default-event element that would
+    # fire without interaction (<details> toggle fires on the initial `open`).
+    details = scrub(%(<details open data-action="lightbox#open:prevent"><summary>s</summary></details>))
+    assert_not_includes details, "data-action"
+    div = scrub(%(<div data-action="lightbox#open:prevent">x</div>))
+    assert_not_includes div, "data-action"
+  end
+
+  test "strips value-sensitive iframe attributes but keeps safe embed attributes" do
+    result = scrub(%(<iframe src="https://ex.com" allow="camera" referrerpolicy="unsafe-url" sandbox="allow-scripts" allowfullscreen frameborder="0"></iframe>))
+    assert_not_includes result, "allow="
+    assert_not_includes result, "referrerpolicy"
+    assert_not_includes result, "sandbox"
+    assert_includes result, "allowfullscreen"
+    assert_includes result, %(frameborder="0")
+  end
+
+  test "preserves the Markdown renderer's header anchor accessibility markup" do
+    result = render_and_scrub("# Introduction")
+    assert_includes result, %(id="introduction")
+    assert_includes result, %(aria-hidden="true")
+  end
+
+  test "preserves ARIA, role, and safe authored link attributes" do
+    result = scrub(%(<a href="/x" target="_blank" rel="noopener" dir="rtl" tabindex="0" aria-label="open" role="button">y</a>))
+    assert_includes result, %(target="_blank")
+    assert_includes result, %(rel="noopener")
+    assert_includes result, %(dir="rtl")
+    assert_includes result, %(tabindex="0")
+    assert_includes result, %(aria-label="open")
+    assert_includes result, %(role="button")
+  end
+
+  test "preserves legitimate formatting, media, and table markup" do
+    assert_includes scrub("<p>Hello <strong>world</strong> <em>now</em></p>"), "<strong>world</strong>"
+    assert_includes scrub(%(<a href="https://example.com" title="t">link</a>)), %(href="https://example.com")
+    video = scrub(%(<video src="/uploads/v.mp4" controls></video>))
+    assert_includes video, "<video"
+    assert_includes video, "controls"
+    table = scrub("<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>D</td></tr></tbody></table>")
+    assert_includes table, "<th>H</th>"
+    assert_includes table, "<td>D</td>"
+  end
+end


### PR DESCRIPTION
## Problem

`HtmlScrubber` (the sanitizer applied to rendered Markdown page content) sets an allowed-**tag** list but never sets an allowed-**attribute** list. When `Rails::Html::PermitScrubber` has no attribute list, it falls back to Loofah's default attribute handling, which permits **all `data-*` attributes**.

That fallback lets editor-authored page content persist a self-firing Stimulus controller — e.g. `data-controller` + `data-action` wired to a lifecycle event — and execute arbitrary **same-origin JavaScript on page view, with no user interaction**. Because the rendered content runs in the app origin, this escalates to acting as the viewer (including an admin viewer).

Inline event handlers (`onload`, `onerror`) and `iframe srcdoc` happen to be stripped by the current Loofah default, but only implicitly — nothing in this app pins that behavior, so a dependency default shift would silently reopen the hole.

## Fix

Set an explicit attribute allowlist on `HtmlScrubber`, containing only the attributes the permitted tags legitimately need (media playback controls, table/iframe layout attributes, and the previously-relied-on `id`/`style`).

With an explicit allowlist, `PermitScrubber` is deny-by-default:

- inline event handlers (`on*`) — dropped
- `data-controller` / `data-action` / `data-turbo-*` and all other `data-*` — dropped
- `iframe srcdoc` — dropped
- URL-valued attributes (`href`, `src`) keep their `javascript:`-scheme scrubbing
- `style` values continue to be CSS-scrubbed

This turns the sanitizer's safety from an implicit dependency default into an explicit, tested contract, and closes the `data-*` script-execution vector.

## Tests

- New `test/models/html_scrubber_test.rb` asserts the scrubber strips event handlers, `data-*` gadget attributes, `iframe srcdoc`, and `javascript:` URLs, while preserving legitimate formatting, media, and table markup.
- Existing page/sanitization tests continue to pass (full suite green; Brakeman clean; RuboCop clean).