### PR TITLE
Fail closed when an upload's owning book can't be resolved

### DIFF
--- a/app/controllers/action_text/markdown/uploads_controller.rb
+++ b/app/controllers/action_text/markdown/uploads_controller.rb
@@ -51,8 +51,10 @@ class ActionText::Markdown::UploadsController < ApplicationController
 
     # An unpublished book's uploads are as private as the book itself. Serving them to
     # anyone holding the URL made this a way to read them without an access row, and
-    # caching them publicly for a year put them in shared caches besides.
+    # caching them publicly for a year put them in shared caches besides. An attachment
+    # whose owning book can't be resolved has no book to authorize against, so fail
+    # closed rather than letting the nil short-circuit the check.
     def ensure_attachment_readable
-      head :not_found unless @book.nil? || @book.published? || @book.accessable?
+      head :not_found unless @book&.published? || @book&.accessable?
     end
 end

--- a/test/controllers/action_text/markdown/uploads_controller_test.rb
+++ b/test/controllers/action_text/markdown/uploads_controller_test.rb
@@ -131,6 +131,21 @@ class ActionText::Markdown::UploadsControllerTest < ActionDispatch::IntegrationT
     assert_response :not_found
   end
 
+  test "an attachment whose owning book can't be resolved is not served" do
+    books(:handbook).update! published: false
+    attachment = attach_upload_to_welcome_page
+
+    # Sever the leaf without cascading the destroy, leaving the attachment live but
+    # its owning book unresolvable. The guard must fail closed on the nil book.
+    pages(:welcome).leaf.delete
+    assert_nil pages(:welcome).reload.owning_book
+
+    reset!
+    get action_text_markdown_upload_url(slug: attachment.slug)
+
+    assert_response :not_found
+  end
+
   test "an attachment of an unpublished book is served to a reader, but not publicly cached" do
     books(:handbook).update! published: false
     attachment = attach_upload_to_welcome_page

--- a/test/controllers/action_text/markdown/uploads_controller_test.rb
+++ b/test/controllers/action_text/markdown/uploads_controller_test.rb
@@ -141,7 +141,7 @@ class ActionText::Markdown::UploadsControllerTest < ActionDispatch::IntegrationT
     assert_nil pages(:welcome).reload.owning_book
 
     reset!
-    get action_text_markdown_upload_url(slug: attachment.slug)
+    get action_text_markdown_upload_path(slug: attachment.slug)
 
     assert_response :not_found
   end


### PR DESCRIPTION
`ActionText::Markdown::UploadsController#ensure_attachment_readable` listed `@book.nil?` as the first allowed condition:

```ruby
head :not_found unless @book.nil? || @book.published? || @book.accessable?
```

When `set_attachment` can't resolve an owning book — `@attachment.record.try(:record).try(:owning_book)` returns `nil` — the `nil?` branch short-circuits the guard and the file is served (and, for the show path, potentially cached publicly). That's the opposite of the invariant the guard exists to hold: an unpublished book's uploads are as private as the book itself.

A live attachment reaches a nil owning book when its leaf is severed without the destroy cascade that would otherwise purge the attachment along with its markdown record. The guard should treat "no book to authorize against" as deny, not allow.

## Fix

Drop the `nil` branch and use safe navigation, so a nil book fails both checks and 404s:

```ruby
head :not_found unless @book&.published? || @book&.accessable?
```

Published and accessible books are unaffected — every existing serving test still passes.

## Test

Adds a regression test: an attachment whose owning book can't be resolved is not served (404), asserted for an anonymous client against an unpublished book.